### PR TITLE
Fixed PROGMEM example, and updated for modern IDE.

### DIFF
--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -16,7 +16,7 @@ Store data in flash (program) memory instead of SRAM. There's a description of t
 
 The `PROGMEM` keyword is a variable modifier, it should be used only with the datatypes defined in pgmspace.h. It tells the compiler "put this information into flash memory", instead of into SRAM, where it would normally go.
 
-    PROGMEM is part of the http://www.nongnu.org/avr-libc/user-manual/group__avr__pgmspace.html[pgmspace.h] library. So you first need to include the library at the top your sketch, like this:
+    PROGMEM is part of the http://www.nongnu.org/avr-libc/user-manual/group__avr__pgmspace.html[pgmspace.h] library. It is included automatically in modern versions of the IDE, however if you are using an IDE version below 1.0 (2011), you'll first need to include the library at the top your sketch, like this:
 
 `#include <avr/pgmspace.h>`
 [%hardbreaks]
@@ -58,9 +58,6 @@ The following code fragments illustrate how to read and write unsigned chars (by
 
 [source,arduino]
 ----
-#include <avr/pgmspace.h>
-
-
 // save some unsigned ints
 const PROGMEM  uint16_t charSet[]  = { 65000, 32796, 16843, 10, 11234};
 
@@ -86,7 +83,7 @@ void setup() {
   Serial.println();
 
   // read back a char
-  for (k = 0; k < strlen(signMessage); k++)
+  for (k = 0; k < strlen_P(signMessage); k++)
   {
     myChar =  pgm_read_byte_near(signMessage + k);
     Serial.print(myChar);


### PR DESCRIPTION
An example in the PROGMEM documentation uses `strlen` instead of `strlen_P` to access data stored using PROGMEM.
Also, since version 1.0 of the IDE (2011) the file `avr/pgmspace.h` no longer needs to be included ([Added to Arduino.h](https://github.com/arduino/Arduino/blame/ide-1.0.x/hardware/arduino/cores/arduino/Arduino.h#L27)).

See: https://github.com/arduino/Arduino/issues/3430
