### PR TITLE
Correction to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Thank you for taking the time to contribute to Arduino content, this is really h
 ##Content Creation and Editing##
 If you want to contribute new content, create a new file (with any text or code editor) and save it as .adoc.  
 Do not use parenthesis or any special character in the file name.  
-In refernce-en/AsciiDoc_sample/AsciiDoc_Dictionary you will find an overview on the AsciiDoc syntax in use on the Manutius platform. This includes Titles, Text, Links, Images, Tables, Code and various embeds (video, slideshow, audio and code).
+In reference-en/AsciiDoc_sample/AsciiDoc_Dictionary you will find an overview on the AsciiDoc syntax in use on the Manutius platform. This includes Titles, Text, Links, Images, Tables, Code and various embeds (video, slideshow, audio and code).
 
 If you want to contribute to the Language Reference or edit existing content, you can find two templates in reference-en/AsciiDoc_sample/Reference_Terms:
 * Use AsciiDoc_Template-Single_Entity.adoc for terms such as [`analogWrite`](http://arduino.cc/en/Reference/AnalogWrite).


### PR DESCRIPTION
Line 12 in README.md had a minor typo in the path for AsciiDoc templates ("In **refernce**-en/AsciiDoc_sample/AsciiDoc_Dictionary you will find..."). I changed it to "In reference..."