### PR TITLE
Fix `int` documentation on overflow (which is UB)

### DIFF
--- a/Language/Variables/Data Types/int.adoc
+++ b/Language/Variables/Data Types/int.adoc
@@ -53,17 +53,8 @@ The Arduino takes care of dealing with negative numbers for you, so that arithme
 
 [float]
 === Notes and Warnings
-When variables are made to exceed their maximum capacity they "roll over" back to their minimum capacity, note that this happens in both directions.
-[source,arduino]
-----
-int x;
-   x = -32768;
-   x = x - 1;       // x now contains 32,767 - rolls over in neg. direction
+When signed variables are made to exceed their maximum or minimum capacity they _overflow_.  The result of an overflow is unpredictable so this should be avoided.  A typical symptom of an overflow is the variable "rolling over" from its maximum capacity to its minimum or vice versa, but this is not always the case.  If you want this behavior, use link:unsignedInt{ext-relative}[unsigned int].
 
-   x = 32767;
-   x = x + 1;       // x now contains -32,768 - rolls over
-
-----
 [%hardbreaks]
 
 [float]

--- a/Language/Variables/Data Types/unsignedInt.adoc
+++ b/Language/Variables/Data Types/unsignedInt.adoc
@@ -46,11 +46,11 @@ The difference between unsigned ints and (signed) ints, lies in the way the high
 
 [float]
 === Notes and Warnings
-When variables are made to exceed their maximum capacity they "roll over" back to their minimum capacitiy, note that this happens in both directions
+When unsigned variables are made to exceed their maximum capacity they "roll over" back to 0, and also the other way around:
 
 [source,arduino]
 ----
-unsigned int x
+unsigned int x;
    x = 0;
    x = x - 1;       // x now contains 65535 - rolls over in neg direction
    x = x + 1;       // x now contains 0 - rolls over


### PR DESCRIPTION
The documentation says that if you add 1 to an int variable whose value is 32767 it'll just "roll over" to -32768, but this is actually undefined behavior (for signed integers of any length) and can't be trusted in behaving consistently.  Example:

```
boolean will_overflow(int x) {
    int y = x+1;
    return y < x; // compiler assumes this will never happen => will always return false
}

    will_overflow(INT_MAX)  // returns false instead of true
```

Notice that this is not the case for unsigned integer types, which are required to "roll over" as documented.
