### PR TITLE
Fixed Returns section in micros() function

### DIFF
--- a/Language/Functions/Time/micros.adoc
+++ b/Language/Functions/Time/micros.adoc
@@ -33,7 +33,7 @@ Nothing
 
 [float]
 === Returns
-Nothing
+Returns the number of microseconds since the Arduino board began running the current program.(unsigned long)
 
 --
 // OVERVIEW SECTION ENDS


### PR DESCRIPTION
Returns section inaccurately indicated the function returns nothing, fixed to accurately portray the returned value.