### PR TITLE
Fix docs on Serial.readBytes return value

### DIFF
--- a/Language/Functions/Communication/Serial/readBytes.adoc
+++ b/Language/Functions/Communication/Serial/readBytes.adoc
@@ -33,7 +33,7 @@
 
 [float]
 === Returns
-`byte`
+The number of bytes placed in the buffer (`size_t`)
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamReadBytes.adoc
+++ b/Language/Functions/Communication/Stream/streamReadBytes.adoc
@@ -38,7 +38,7 @@ This function is part of the Stream class, and is called by any class that inher
 
 [float]
 === Returns
-The number of bytes placed in the buffer.
+The number of bytes placed in the buffer (`size_t`)
 
 --
 // OVERVIEW SECTION ENDS


### PR DESCRIPTION
The way the docs were worded, it looked like the `readBytes` function
would return a value of type `byte`, even though that's not true. When
using a `byte` typed variable to store the number of bytes read value,
an overflow occurs.

According to the source code, the return type is `size_t`.