### PR TITLE
Update longCast.adoc

### DIFF
--- a/Language/Variables/Conversion/longCast.adoc
+++ b/Language/Variables/Conversion/longCast.adoc
@@ -41,8 +41,8 @@ Converts a value to the link:../../data-types/long[long] data type.
 
 
 
-// HOW TO USE SECTION STARTS
-[#howtouse]
+// SEE ALSO SECTION STARTS
+[#see_also]
 --
 
 [float]
@@ -55,4 +55,4 @@ Converts a value to the link:../../data-types/long[long] data type.
 
 
 --
-// HOW TO USE SECTION ENDS
+// SEE ALSO SECTION ENDS


### PR DESCRIPTION
Removed empty "How to use" section
Moved "see also" section to a section of its own.