### PR TITLE
Fix typo in isSpace() syntax section

### DIFF
--- a/Language/Functions/Characters/isSpace.adoc
+++ b/Language/Functions/Characters/isSpace.adoc
@@ -26,7 +26,7 @@ Analyse if a char is the space character. Returns true if thisChar contains a le
 === Syntax
 [source,arduino]
 ----
-`isAlpha(thisChar)`
+`isSpace(thisChar)`
 ----
 
 [float]


### PR DESCRIPTION
The isSpace() page's syntax section previously had isAlpha rather than isSpace.

Originally reported at http://forum.arduino.cc/index.php?topic=496595.msg3457315#msg3457315