### PR TITLE
Move Mouse library example links from the Keyboard library page to the Mouse library page

### DIFF
--- a/Language/Functions/USB/Keyboard.adoc
+++ b/Language/Functions/USB/Keyboard.adoc
@@ -70,8 +70,6 @@ link:../keyboard/keyboardwrite[Keyboard.write()]
 * #EXAMPLE# http://www.arduino.cc/en/Tutorial/KeyboardLogout[KeyboardLogout]: Logs out the current user with key commands
 * #EXAMPLE# http://www.arduino.cc/en/Tutorial/KeyboardSerial[KeyboardSerial]: Reads a byte from the serial port, and sends back a keystroke.
 * #EXAMPLE# http://www.arduino.cc/en/Tutorial/KeyboardReprogram[KeyboardReprogram]: opens a new window in the Arduino IDE and reprograms the board with a simple blink program
-* #EXAMPLE# http://www.arduino.cc/en/Tutorial/ButtonMouseControl[ButtonMouseControl]: Control cursor movement with 5 pushbuttons.
-* #EXAMPLE# http://www.arduino.cc/en/Tutorial/JoystickMouseControl[JoystickMouseControl]: Controls a computer's cursor movement with a Joystick when a button is pressed.
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/USB/Mouse.adoc
+++ b/Language/Functions/USB/Mouse.adoc
@@ -53,3 +53,20 @@ link:../mouse/mouseispressed[Mouse.isPressed()]
 
 --
 // FUNCTIONS SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+[role="example"]
+* #EXAMPLE# http://www.arduino.cc/en/Tutorial/KeyboardAndMouseControl[KeyboardAndMouseControl]: Demonstrates the Mouse and Keyboard commands in one program.
+* #EXAMPLE# http://www.arduino.cc/en/Tutorial/ButtonMouseControl[ButtonMouseControl]: Control cursor movement with 5 pushbuttons.
+* #EXAMPLE# http://www.arduino.cc/en/Tutorial/JoystickMouseControl[JoystickMouseControl]: Controls a computer's cursor movement with a Joystick when a button is pressed.
+
+--
+// SEE ALSO SECTION ENDS
+


### PR DESCRIPTION
The link to the KeyboardAndMouseControl example was left in both pages as it's relevant to either.