### PR TITLE
Fix typos in const page

### DIFF
--- a/Language/Variables/Variable Scope & Qualifiers/const.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/const.adoc
@@ -20,7 +20,7 @@ subCategories: [ "Variable Scope & Qualifiers" ]
 === Description
 The `const` keyword stands for constant. It is a variable _qualifier_ that modifies the behavior of the variable, making a variable "_read-only_". This means that the variable can be used just as any other variable of its type, but its value cannot be changed. You will get a compiler error if you try to assign a value to a `const` variable.
 
-Constants defined with the const keyword obey the rules of link:../scope[variable scoping] that govern other variables. This, and the pitfalls of using#define, makes the const keyword a superior method for defining constants and is preferred over using link:../../../structure/further-syntax/define[#define].
+Constants defined with the `const` keyword obey the rules of link:../scope[variable scoping] that govern other variables. This, and the pitfalls of using `#define`, makes the `const` keyword a superior method for defining constants and is preferred over using link:../../../structure/further-syntax/define[`#define`].
 [%hardbreaks]
 
 --
@@ -45,7 +45,7 @@ float x;
 
 // ....
 
-x = pi * 2;    // it's fine to use const's in math
+x = pi * 2;    // it's fine to use consts in math
 
 pi = 7;        // illegal - you can't write to (modify) a constant
 


### PR DESCRIPTION
Includes fixes for regressions of typos reported in https://github.com/arduino/Arduino/issues/6506 and previously fixed.