### PR TITLE
Fix incorrect comments re: which click in Mouse example codes

### DIFF
--- a/Language/Functions/USB/Mouse/mouseClick.adoc
+++ b/Language/Functions/USB/Mouse/mouseClick.adoc
@@ -63,7 +63,7 @@ void setup(){
 }
 
 void loop(){
-  //if the button is pressed, send a Right mouse click
+  //if the button is pressed, send a left mouse click
   if(digitalRead(2) == HIGH){
     Mouse.click();
   }

--- a/Language/Functions/USB/Mouse/mouseEnd.adoc
+++ b/Language/Functions/USB/Mouse/mouseEnd.adoc
@@ -56,7 +56,7 @@ void setup(){
 }
 
 void loop(){
-  //if the button is pressed, send a Right mouse click
+  //if the button is pressed, send a left mouse click
   //then end the Mouse emulation
   if(digitalRead(2) == HIGH){
     Mouse.click();

--- a/Language/Functions/USB/Mouse/mouseIsPressed.adoc
+++ b/Language/Functions/USB/Mouse/mouseIsPressed.adoc
@@ -71,12 +71,12 @@ void setup(){
 void loop(){
   //a variable for checking the button's state
   int mouseState=0;
-  //if the switch attached to pin 2 is closed, press and hold the right mouse button and save the state ina  variable
+  //if the switch attached to pin 2 is closed, press and hold the left mouse button and save the state ina  variable
   if(digitalRead(2) == HIGH){
     Mouse.press();
     mouseState=Mouse.isPressed();
   }
-  //if the switch attached to pin 3 is closed, release the right mouse button and save the state in a variable
+  //if the switch attached to pin 3 is closed, release the left mouse button and save the state in a variable
   if(digitalRead(3) == HIGH){
     Mouse.release();
     mouseState=Mouse.isPressed();

--- a/Language/Functions/USB/Mouse/mousePress.adoc
+++ b/Language/Functions/USB/Mouse/mousePress.adoc
@@ -70,11 +70,11 @@ void setup(){
 }
 
 void loop(){
-  //if the switch attached to pin 2 is closed, press and hold the right mouse button
+  //if the switch attached to pin 2 is closed, press and hold the left mouse button
   if(digitalRead(2) == HIGH){
     Mouse.press();
   }
-  //if the switch attached to pin 3 is closed, release the right mouse button
+  //if the switch attached to pin 3 is closed, release the left mouse button
   if(digitalRead(3) == HIGH){
     Mouse.release();
   }

--- a/Language/Functions/USB/Mouse/mouseRelease.adoc
+++ b/Language/Functions/USB/Mouse/mouseRelease.adoc
@@ -65,11 +65,11 @@ void setup(){
 }
 
 void loop(){
-  //if the switch attached to pin 2 is closed, press and hold the right mouse button
+  //if the switch attached to pin 2 is closed, press and hold the left mouse button
   if(digitalRead(2) == HIGH){
     Mouse.press();
   }
-  //if the switch attached to pin 3 is closed, release the right mouse button
+  //if the switch attached to pin 3 is closed, release the left mouse button
   if(digitalRead(3) == HIGH){
     Mouse.release();
   }


### PR DESCRIPTION
The default argument of these functions is MOUSE_LEFT.

These are fixes for regressions of issues previously reported and fixed:
- https://github.com/arduino/Arduino/issues/6501
- https://github.com/arduino/Arduino/issues/6500
- https://github.com/arduino/Arduino/issues/6499
- https://github.com/arduino/Arduino/issues/6498