### PR TITLE
Use correct function name in readStringUntil() syntax section

### DIFF
--- a/Language/Functions/Communication/Serial/readStringUntil.adoc
+++ b/Language/Functions/Communication/Serial/readStringUntil.adoc
@@ -24,7 +24,7 @@ This function is part of the Stream class, and is called by any class that inher
 
 [float]
 === Syntax
-`Serial.readString(terminator)`
+`Serial.readStringUntil(terminator)`
 
 
 [float]


### PR DESCRIPTION
Fixes regression of previously reported/fixed issue https://github.com/arduino/Arduino/issues/3734