### PR TITLE
Include Keyboard and Mouse libraries in examples

### DIFF
--- a/Language/Functions/USB/Keyboard/keyboardBegin.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardBegin.adoc
@@ -49,6 +49,8 @@ Nothing
 
 [source,arduino]
 ----
+#include <Keyboard.h>
+
 void setup() {
   // make pin 2 an input and turn on the
   // pullup resistor so it goes high unless

--- a/Language/Functions/USB/Keyboard/keyboardEnd.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardEnd.adoc
@@ -49,6 +49,8 @@ Nothing
 
 [source,arduino]
 ----
+#include <Keyboard.h>
+
 void setup() {
   //start keyboard communication
   Keyboard.begin();

--- a/Language/Functions/USB/Keyboard/keyboardPress.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPress.adoc
@@ -51,6 +51,8 @@ Nothing
 
 [source,arduino]
 ----
+#include <Keyboard.h>
+
 // use this option for OSX:
 char ctrlKey = KEY_LEFT_GUI;
 // use this option for Windows and Linux:

--- a/Language/Functions/USB/Keyboard/keyboardPrint.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPrint.adoc
@@ -51,6 +51,8 @@ Sends a keystroke to a connected computer.
 
 [source,arduino]
 ----
+#include <Keyboard.h>
+
 void setup() {
   // make pin 2 an input and turn on the
   // pullup resistor so it goes high unless

--- a/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
@@ -52,6 +52,8 @@ Sends a keystroke to a connected computer, followed by a newline and carriage re
 
 [source,arduino]
 ----
+#include <Keyboard.h>
+
 void setup() {
   // make pin 2 an input and turn on the
   // pullup resistor so it goes high unless

--- a/Language/Functions/USB/Keyboard/keyboardRelease.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardRelease.adoc
@@ -49,6 +49,8 @@ Lets go of the specified key. See link:../keyboardpress[Keyboard.press()] for mo
 
 [source,arduino]
 ----
+#include <Keyboard.h>
+
 // use this option for OSX:
 char ctrlKey = KEY_LEFT_GUI;
 // use this option for Windows and Linux:

--- a/Language/Functions/USB/Keyboard/keyboardReleaseAll.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardReleaseAll.adoc
@@ -48,6 +48,8 @@ Nothing
 
 [source,arduino]
 ----
+#include <Keyboard.h>
+
 // use this option for OSX:
 char ctrlKey = KEY_LEFT_GUI;
 // use this option for Windows and Linux:

--- a/Language/Functions/USB/Keyboard/keyboardWrite.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardWrite.adoc
@@ -60,6 +60,8 @@ Keyboard.write(0b01000001); // same thing in binary (weird choice, but it works)
 
 [source,arduino]
 ----
+#include <Keyboard.h>
+
 void setup() {
   // make pin 2 an input and turn on the
   // pullup resistor so it goes high unless

--- a/Language/Functions/USB/Mouse/mouseBegin.adoc
+++ b/Language/Functions/USB/Mouse/mouseBegin.adoc
@@ -50,6 +50,8 @@ Nothing
 
 [source,arduino]
 ----
+#include <Mouse.h>
+
 void setup(){
  pinMode(2, INPUT);
 }

--- a/Language/Functions/USB/Mouse/mouseClick.adoc
+++ b/Language/Functions/USB/Mouse/mouseClick.adoc
@@ -56,6 +56,8 @@ Nothing
 
 [source,arduino]
 ----
+#include <Mouse.h>
+
 void setup(){
   pinMode(2,INPUT);
   //initiate the Mouse library

--- a/Language/Functions/USB/Mouse/mouseEnd.adoc
+++ b/Language/Functions/USB/Mouse/mouseEnd.adoc
@@ -49,6 +49,8 @@ Nothing
 
 [source,arduino]
 ----
+#include <Mouse.h>
+
 void setup(){
   pinMode(2,INPUT);
   //initiate the Mouse library

--- a/Language/Functions/USB/Mouse/mouseIsPressed.adoc
+++ b/Language/Functions/USB/Mouse/mouseIsPressed.adoc
@@ -57,6 +57,8 @@ When there is no value passed, it checks the status of the left mouse button.
 
 [source,arduino]
 ----
+#include <Mouse.h>
+
 void setup(){
   //The switch that will initiate the Mouse press
   pinMode(2,INPUT);

--- a/Language/Functions/USB/Mouse/mouseMove.adoc
+++ b/Language/Functions/USB/Mouse/mouseMove.adoc
@@ -52,6 +52,8 @@ Nothing
 
 [source,arduino]
 ----
+#include <Mouse.h>
+
 const int xAxis = A1;         //analog sensor for X axis
 const int yAxis = A2;         // analog sensor for Y axis
 

--- a/Language/Functions/USB/Mouse/mousePress.adoc
+++ b/Language/Functions/USB/Mouse/mousePress.adoc
@@ -60,6 +60,8 @@ Nothing
 
 [source,arduino]
 ----
+#include <Mouse.h>
+
 void setup(){
   //The switch that will initiate the Mouse press
   pinMode(2,INPUT);

--- a/Language/Functions/USB/Mouse/mouseRelease.adoc
+++ b/Language/Functions/USB/Mouse/mouseRelease.adoc
@@ -55,6 +55,8 @@ Nothing
 
 [source,arduino]
 ----
+#include <Mouse.h>
+
 void setup(){
   //The switch that will initiate the Mouse press
   pinMode(2,INPUT);


### PR DESCRIPTION
Keyboard and Mouse are now libraries and thus they must be `#include`d. Without that none of these examples will compile with any version of the Arduino IDE newer than 1.6.5.