### PR TITLE
Document all String constructor parameters

### DIFF
--- a/Language/Variables/Data Types/stringObject.adoc
+++ b/Language/Variables/Data Types/stringObject.adoc
@@ -64,7 +64,9 @@ String(val, decimalPlaces)
 
 [float]
 === Parameters
-`val`:  a variable to format as a String - *Allowed data types:* string, char, byte, int, long, unsigned int, unsigned long, float, double
+`val`:  a variable to format as a String - *Allowed data types:* string, char, byte, int, long, unsigned int, unsigned long, float, double +
+`base` (optional): the base in which to format an integral value
+`decimalPlaces` (*only if val is float or double*): the desired decimal places
 
 [float]
 === Returns


### PR DESCRIPTION
Fixes a regression from the previous reference page

Based on https://www.arduino.cc/en/Reference/StringConstructor