### PR TITLE
Don't use camelcase in link to availableForWrite page

### DIFF
--- a/Language/Functions/Communication/serial.adoc
+++ b/Language/Functions/Communication/serial.adoc
@@ -40,7 +40,7 @@ The *Arduino Leonardo* board uses `Serial1` to communicate via TTL (5V) serial o
 === Functions
 link:../serial/ifserial[If] (Serial) +
 link:../serial/available[available()] +
-link:../serial/availableForWrite[availableForWrite()] +
+link:../serial/availableforwrite[availableForWrite()] +
 link:../serial/begin[begin()] +
 link:../serial/end[end()] +
 link:../serial/find[find()] +


### PR DESCRIPTION
It appears from looking at the rest of the page that links must be all lower case.

Fixes bug I introduced in https://github.com/arduino/reference-en/commit/5dec68381dfb03c53f4a2c3e24fb93fd3e6e69c9