### PR TITLE
Document supported analogReference values for SAMD and SAM

### DIFF
--- a/Language/Functions/Analog IO/analogReference.adoc
+++ b/Language/Functions/Analog IO/analogReference.adoc
@@ -19,11 +19,27 @@ subCategories: [ "Analog I/O" ]
 === Description
 Configures the reference voltage used for analog input (i.e. the value used as the top of the input range). The options are:
 
+Arduino AVR Boards (Uno, Mega, etc.)
+
 * DEFAULT: the default analog reference of 5 volts (on 5V Arduino boards) or 3.3 volts (on 3.3V Arduino boards)
 * INTERNAL: an built-in reference, equal to 1.1 volts on the ATmega168 or ATmega328P and 2.56 volts on the ATmega8 (not available on the Arduino Mega)
 * INTERNAL1V1: a built-in 1.1V reference (Arduino Mega only)
 * INTERNAL2V56: a built-in 2.56V reference (Arduino Mega only)
 * EXTERNAL: the voltage applied to the AREF pin (0 to 5V only) is used as the reference.
+
+Arduino SAMD Boards (Zero, etc.)
+
+* AR_DEFAULT: the default analog reference of 3.3V
+* AR_INTERNAL: a built-in 2.23V reference
+* AR_INTERNAL1V0: a built-in 1.0V reference
+* AR_INTERNAL1V65: a built-in 1.65V reference
+* AR_INTERNAL2V23: a built-in 2.23V reference
+* AR_EXTERNAL: the voltage applied to the AREF pin is used as the reference
+
+Arduino SAM Boards (Due)
+
+* AR_DEFAULT: the default analog reference of 3.3V. This is the only supported option for the Due.
+
 [%hardbreaks]
 
 
@@ -34,7 +50,7 @@ Configures the reference voltage used for analog input (i.e. the value used as t
 
 [float]
 === Parameters
-`type`: which type of reference to use (DEFAULT, INTERNAL, INTERNAL1V1, INTERNAL2V56, or EXTERNAL).
+`type`: which type of reference to use (see list of options in the description).
 
 [float]
 === Returns


### PR DESCRIPTION
References:
- https://github.com/arduino/ArduinoCore-samd/blob/1.6.16/cores/arduino/wiring_analog.c#L99-L120
- https://github.com/arduino/ArduinoCore-sam/blob/2a17b0d9daa5ae20630553c4877f88e28f3e44a3/cores/arduino/wiring_analog.h#L27-L40

I guessed that `AR_DEFAULT` is 3.3 V. If that's wrong please let me know and I will update this PR.

EDIT: This PR was approved by ladyada (https://github.com/arduino/reference-en/issues/266#issuecomment-346916738).

Fixes https://github.com/arduino/reference-en/issues/266

I actually think the structure of this page is kind of awkward with the list of supported values for the `type` parameter listed in the description rather than in the parameter documentation but any structural change is beyond the scope of this commit.