### PR TITLE
Fixed Link Error

### DIFF
--- a/Language/Functions/Communication/serial.adoc
+++ b/Language/Functions/Communication/serial.adoc
@@ -73,7 +73,7 @@ link:../serial/serialevent[serialEvent()]
 === See also
 
 [role="example"]
-* #EXAMPLE# https://www.arduino.cc/en/Tutorial/ReadAsciiString[ReadAsciiString^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/ReadASCIIString[ReadASCIIString^]
 * #EXAMPLE# https://www.arduino.cc/en/Tutorial/ASCIITable[ASCII TAble^]
 * #EXAMPLE# https://www.arduino.cc/en/Tutorial/Dimmer[Dimmer^]
 * #EXAMPLE# https://www.arduino.cc/en/Tutorial/Graph[Graph^]


### PR DESCRIPTION
Example for ReadASCIIString was referring to ReadAsciiString giving a
404-error.