### PR TITLE
Update analogReference.adoc

### DIFF
--- a/Language/Functions/Analog IO/analogReference.adoc
+++ b/Language/Functions/Analog IO/analogReference.adoc
@@ -29,12 +29,13 @@ Arduino AVR Boards (Uno, Mega, etc.)
 
 Arduino SAMD Boards (Zero, etc.)
 
-* AR_DEFAULT: the default analog reference of 3.3V
-* AR_INTERNAL: a built-in 2.23V reference
-* AR_INTERNAL1V0: a built-in 1.0V reference
-* AR_INTERNAL1V65: a built-in 1.65V reference
-* AR_INTERNAL2V23: a built-in 2.23V reference
+* AR_DEFAULT: the default analog reference of 3.3V (VDDANA)
+* AR_INTERNAL: 1/1.48 VDDANA (only for VDDANA > 2.0V) = 2.23V reference in a 3.3V system
+* AR_INTERNAL1V0: a built-in 1.0V reference -> use this to measure your battery voltage!
+* AR_INTERNAL1V65: 1/2 VDDANA = 1.65V reference in a 3.3 V system
+* AR_INTERNAL2V23: 1/1.48 VDDANA (only for VDDANA > 2.0V) = 2.23V reference in a 3.3V system
 * AR_EXTERNAL: the voltage applied to the AREF pin is used as the reference
+(For Details see Atmel SAMD21 Data sheet, 32.8.2 Reference Control)
 
 Arduino SAM Boards (Due)
 

--- a/Language/Functions/Analog IO/analogReference.adoc
+++ b/Language/Functions/Analog IO/analogReference.adoc
@@ -35,7 +35,7 @@ Arduino SAMD Boards (Zero, etc.)
 * AR_INTERNAL1V65: 1/2 VDDANA = 1.65V reference in a 3.3 V system
 * AR_INTERNAL2V23: 1/1.48 VDDANA (only for VDDANA > 2.0V) = 2.23V reference in a 3.3V system
 * AR_EXTERNAL: the voltage applied to the AREF pin is used as the reference
-(For Details see Atmel SAMD21 Data sheet, 32.8.2 Reference Control)
+(For Details see Atmel SAMD21 Data sheet, 33.8.2 Reference Control)
 
 Arduino SAM Boards (Due)
 


### PR DESCRIPTION
The 1.65V and 2.23V are not generated from a build in reference. They are only calculated by the devider 1/2 and 1/1.48 from the system Voltage. People who want to measure the battery voltage in a system with less than 3.3 Volt have to use the true 1V ref. 
If we don't write this down here correct it can become quite frustrating and timeconsuming to try to measure a bat voltage with the so called 1.65 build in reference... 
Maybe you will find better words to explain it to the Arduino Community but the wording 
"build in reference" 
should only be used for the 1V reference!