### PR TITLE
Document bool data type

### DIFF
--- a/Language/Variables/Data Types/bool.adoc
+++ b/Language/Variables/Data Types/bool.adoc
@@ -1,0 +1,80 @@
+---
+title: bool
+categories: [ "Variables" ]
+subCategories: [ "Data Types" ]
+---
+
+
+
+
+
+= bool
+
+
+// OVERVIEW SECTION STARTS
+[#overview]
+--
+
+[float]
+=== Description
+A `bool` holds one of two values, `true` or `false`. (Each `bool` variable occupies one byte of memory.)
+
+
+[%hardbreaks]
+
+--
+// OVERVIEW SECTION ENDS
+
+
+
+
+// HOW TO USE SECTION STARTS
+[#howtouse]
+--
+
+[float]
+=== Example Code
+// Describe what the example code is all about and add relevant code   ►►►►► THIS SECTION IS MANDATORY ◄◄◄◄◄
+This code shows how to use the `bool` datatype.
+
+[source,arduino]
+----
+int LEDpin = 5;       // LED on pin 5
+int switchPin = 13;   // momentary switch on 13, other side connected to ground
+
+bool running = false;
+
+void setup()
+{
+  pinMode(LEDpin, OUTPUT);
+  pinMode(switchPin, INPUT);
+  digitalWrite(switchPin, HIGH);      // turn on pullup resistor
+}
+
+void loop()
+{
+  if (digitalRead(switchPin) == LOW)
+  {  // switch is pressed - pullup keeps pin high normally
+    delay(100);                        // delay to debounce switch
+    running = !running;                // toggle running variable
+    digitalWrite(LEDpin, running);     // indicate via LED
+  }
+}
+----
+
+--
+// HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION STARTS
+[#see_also]
+--
+
+[float]
+=== See also
+
+[role="language"]
+* #LANGUAGE# link:../../../variables/constants/constants[constants]
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/boolean.adoc
+++ b/Language/Variables/Data Types/boolean.adoc
@@ -17,7 +17,7 @@ subCategories: [ "Data Types" ]
 
 [float]
 === Description
-A `boolean` holds one of two values, `true` or `false`. (Each `boolean` variable occupies one byte of memory.)
+`boolean` is a non-standard type alias for link:../../../variables/data-types/bool/[bool] defined by Arduino. It's recommended to instead use the standard type `bool`, which is identical.
 
 
 [%hardbreaks]
@@ -28,44 +28,6 @@ A `boolean` holds one of two values, `true` or `false`. (Each `boolean` variable
 
 
 
-// HOW TO USE SECTION STARTS
-[#howtouse]
---
-
-[float]
-=== Example Code
-// Describe what the example code is all about and add relevant code   ►►►►► THIS SECTION IS MANDATORY ◄◄◄◄◄
-This code shows how to use the `boolean` datatype.
-
-[source,arduino]
-----
-int LEDpin = 5;       // LED on pin 5
-int switchPin = 13;   // momentary switch on 13, other side connected to ground
-
-boolean running = false;
-
-void setup()
-{
-  pinMode(LEDpin, OUTPUT);
-  pinMode(switchPin, INPUT);
-  digitalWrite(switchPin, HIGH);      // turn on pullup resistor
-}
-
-void loop()
-{
-  if (digitalRead(switchPin) == LOW)
-  {  // switch is pressed - pullup keeps pin high normally
-    delay(100);                        // delay to debounce switch
-    running = !running;                // toggle running variable
-    digitalWrite(LEDpin, running);     // indicate via LED
-  }
-}
-----
-
---
-// HOW TO USE SECTION ENDS
-
-
 // SEE ALSO SECTION STARTS
 [#see_also]
 --
@@ -74,7 +36,7 @@ void loop()
 === See also
 
 [role="language"]
-* #LANGUAGE# link:../../../variables/constants/constants[constants]
+* #LANGUAGE# link:../../../variables/data-types/bool/[bool]
 
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
Previously only Arduino's type alias, boolean was documented.

In this case it's arguable that the benefits of a slightly more descriptive type name outweigh the disadvantages of using a non-standard type. For that reason documenting bool and recommending its use instead of boolean is desirable. Accompanying this documentation change will be a move to use bool instead of boolean in all of the official Arduino code.

This change has been approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633

Closes https://github.com/arduino/Arduino/issues/6657.