### PR TITLE
Update loop.adoc

### DIFF
--- a/Language/Structure/Sketch/loop.adoc
+++ b/Language/Structure/Sketch/loop.adoc
@@ -37,7 +37,7 @@ int buttonPin = 3;
 // setup initializes serial and the button pin
 void setup()
 {
-  beginSerial(9600);
+  Serial.begin(9600);
   pinMode(buttonPin, INPUT);
 }
 
@@ -46,9 +46,9 @@ void setup()
 void loop()
 {
   if (digitalRead(buttonPin) == HIGH)
-    serialWrite('H');
+    Serial.write('H');
   else
-    serialWrite('L');
+    Serial.write('L');
 
   delay(1000);
 }


### PR DESCRIPTION
There is a typo in lines 40, 49 and 51.

Line 40:
Was: beginSerial(9600);
Now: Serial.begin(9600);

Line 49:
Was: serialWrite('H');
Now: Serial.write('H');

Line 51:
Was: serialWrite('L');
Now: Serial.write('L');

After I made the  above proposed changes, the syntax agreed with the existing documentation for "Serial.begin" and "Serial.write" and the little demo program started to work as expected.

Sincerely,
ZWahl

P.S. I'm new to this forum and Arduino.  I tried the above program and had to debug and thought that correcting the "loop" example code would help another newcomer, so please advise on how to proceed to incorporate this change to the loop.adoc.