### PR TITLE
Change "Returns" description

### DIFF
--- a/Language/Functions/Communication/Serial/availableForWrite.adoc
+++ b/Language/Functions/Communication/Serial/availableForWrite.adoc
@@ -35,7 +35,7 @@ Nothing
 
 [float]
 === Returns
-The number of bytes available to read .
+The number of bytes available to write.
 --
 // OVERVIEW SECTION ENDS
 


### PR DESCRIPTION
Change read to write as this function should return the number of bytes in the output buffer if I'm getting this right.

Found this by accident while browsing through the Serial documentation as I'm currently working on some multi device communication case. If I got it right this should be write?