### PR TITLE
Fix Keyboard.adoc and Mouse.adoc

### DIFF
--- a/Language/Functions/USB/Keyboard.adoc
+++ b/Language/Functions/USB/Keyboard.adoc
@@ -16,7 +16,7 @@ subCategories: [ "USB" ]
 
 [float]
 === Description
-The keyboard functions enable a 32u4 or SAMD micro based boards to send keystrokes to an attached computer through their micro's native USB port.
+The keyboard functions enable 32u4 or SAMD micro based boards to send keystrokes to an attached computer through their micro's native USB port.
 [%hardbreaks]
 *Note: Not every possible ASCII character, particularly the non-printing ones, can be sent with the Keyboard library.* +
 The library supports the use of modifier keys. Modifier keys change the behavior of another key when pressed simultaneously. link:../keyboard/keyboardmodifiers[See here] for additional information on supported keys and their use.

--- a/Language/Functions/USB/Mouse.adoc
+++ b/Language/Functions/USB/Mouse.adoc
@@ -18,7 +18,7 @@ subCategories: [ "USB" ]
 
 [float]
 === Description
-The mouse functions enable a 32u4 or SAMD micro based boards to to control cursor movement on a connected computer through their micro's native USB port. When updating the cursor position, it is always relative to the cursor's previous location.
+The mouse functions enable 32u4 or SAMD micro based boards to control cursor movement on a connected computer through their micro's native USB port. When updating the cursor position, it is always relative to the cursor's previous location.
 [%hardbreaks]
 --
 // OVERVIEW SECTION ENDS


### PR DESCRIPTION
This PR fixes a grammatical error in both Keyboard.adoc and Mouse.adoc. 
In Mouse.adoc, an extra "to" was removed.