### PR TITLE
Use standard markup for isWhitespace syntax section

### DIFF
--- a/Language/Functions/Characters/isWhitespace.adoc
+++ b/Language/Functions/Characters/isWhitespace.adoc
@@ -25,9 +25,8 @@ Returns true if thisChar contains a white space.
 [float]
 === Syntax
 [source,arduino]
-----
-isWhitespace(thisChar)
-----
+`isWhitespace(thisChar)`
+
 
 [float]
 === Parameters


### PR DESCRIPTION
Wrapping this line in backticks is the approved markup style, as established by https://raw.githubusercontent.com/arduino/reference-en/master/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Single_Entity.adoc

As previously discussed and approved by SimonePDA at: https://github.com/arduino/reference-en/pull/268#issuecomment-352014503