### PR TITLE
Rename "modulo" to "remainder"

### DIFF
--- a/Language/Structure/Arithmetic Operators/modulo.adoc
+++ b/Language/Structure/Arithmetic Operators/modulo.adoc
@@ -1,6 +1,6 @@
 ---
 title: "%"
-title_expanded: "modulo"
+title_expanded: "remainder"
 categories: [ "Structure" ]
 subCategories: [ "Arithmetic Operators" ]
 ---
@@ -9,7 +9,7 @@ subCategories: [ "Arithmetic Operators" ]
 
 
 
-= % Modulo
+= % Remainder
 
 
 // OVERVIEW SECTION STARTS
@@ -18,7 +18,7 @@ subCategories: [ "Arithmetic Operators" ]
 
 [float]
 === Description
-*Modulo* operation calculates the remainder when one integer is divided by another. It is useful for keeping a variable within a particular range (e.g. the size of an array). The `%` (percent) symbol is used to carry out modulo operation.
+*Remainder* operation calculates the remainder when one integer is divided by another. It is useful for keeping a variable within a particular range (e.g. the size of an array). The `%` (percent) symbol is used to carry out remainder operation.
 [%hardbreaks]
 
 
@@ -55,6 +55,8 @@ x = 7 % 5;    // x now contains 2
 x = 9 % 5;    // x now contains 4
 x = 5 % 5;    // x now contains 0
 x = 4 % 5;    // x now contains 4
+x = -4 % 5;   // x now contains -4
+x = 4 % -5;   // x now contains 4
 ----
 
 [source,arduino]
@@ -69,14 +71,17 @@ void setup() {}
 void loop()
 {
   values[i] = analogRead(0);
-  i = (i + 1) % 10;   // modulo operator rolls over variable
+  i = (i + 1) % 10;   // remainder operator rolls over variable
 }
 ----
 [%hardbreaks]
 
 [float]
 === Notes and Warnings
-The modulo operator does not work on floats.
+1. The remainder operator does not work on floats.
+
+2. If the *first* operand is negative, the result is negative (or zero).
+Therefore, the result of `x % 10` will not always be between 0 and 9 if `x` can be negative.
 [%hardbreaks]
 
 --


### PR DESCRIPTION
When negative numbers are involved, *"modulo"* typically refers to an operation that has the same sign as the second operand, whereas *"remainder"* has the sign of the first (this distinction is clear e.g. in the Ada language, which has both `mod` and `rem` operators).  Specifically, the standard refers to the result of `%` as "remainder", not "modulo".
In Python, for example, `(-11) % 10` is 9, but in C and C++ it is -1).  This can be a problem if `%` is being used to restrict an array index to a range (e.g. to implement a circular buffer), if said index can be negative.

I have replaced all occurrences of "modulo" with "remainder" in `modulo.adoc`, and provided two examples of what happens when you use `%` with negative operands.  However I have left the file name as "`modulo.adoc`" (because honestly I have no idea what happens if you mess with the file names).