### PR TITLE
Link to avr-libc documentation for PROGMEM funcs

### DIFF
--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -185,6 +185,7 @@ The following code WILL work, even if locally defined within a function:
 const static char long_str[] PROGMEM = "Hi, I would like to tell you a bit about myself.\n"
 ----
 
+[float]
 === The `F()` macro
 
 When an instruction like :
@@ -213,6 +214,9 @@ Serial.print(F("Write something on the Serial Monitor that is stored in FLASH"))
 
 [role="example"]
 * #EXAMPLE# https://www.arduino.cc/playground/Learning/Memory[Types of memory available on an Arduino board]
+
+[role="language"]
+* #LANGUAGE# link:https://www.nongnu.org/avr-libc/user-manual/group__avr__pgmspace.html[Program space functions in avr-libc]
 
 [role="definition"]
 * #DEFINITION# link:../../data-types/array[array]


### PR DESCRIPTION
This change adds a link to the avr-libc documentation of progmem functions, so that folks can see all kinds of functions available and choose the one that fits them most. This also answers where all the functions used here come from.