### PR TITLE
Replace usage of boolean with bool

### DIFF
--- a/Language/Functions/Communication/Serial/find.adoc
+++ b/Language/Functions/Communication/Serial/find.adoc
@@ -30,7 +30,7 @@ Serial.find() inherits from the link:../../stream[stream] utility class.
 
 [float]
 === Returns
-`boolean`
+`bool`
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/findUntil.adoc
+++ b/Language/Functions/Communication/Serial/findUntil.adoc
@@ -34,7 +34,7 @@ The function returns true if the target string is found, false if it times out.
 
 [float]
 === Returns
-`boolean`
+`bool`
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/ifSerial.adoc
+++ b/Language/Functions/Communication/Serial/ifSerial.adoc
@@ -44,7 +44,7 @@ Nothing
 
 [float]
 === Returns
-`boolean` : returns true if the specified serial port is available. This will only return false if querying the Leonardo's USB CDC serial connection before it is ready.
+`bool` : returns true if the specified serial port is available. This will only return false if querying the Leonardo's USB CDC serial connection before it is ready.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamFind.adoc
+++ b/Language/Functions/Communication/Stream/streamFind.adoc
@@ -33,7 +33,7 @@ This function is part of the Stream class, and is called by any class that inher
 
 [float]
 === Returns
-`boolean`
+`bool`
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamFindUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamFindUntil.adoc
@@ -33,7 +33,7 @@ This function is part of the Stream class, and is called by any class that inher
 
 [float]
 === Returns
-`boolean`
+`bool`
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/USB/Mouse/mouseIsPressed.adoc
+++ b/Language/Functions/USB/Mouse/mouseIsPressed.adoc
@@ -37,7 +37,7 @@ When there is no value passed, it checks the status of the left mouse button.
 
 [float]
 === Returns
-`boolean` : reports whether a button is pressed or not.
+`bool` : reports whether a button is pressed or not.
 
 --
 // OVERVIEW SECTION ENDS


### PR DESCRIPTION
The actual return types of these functions is bool, not boolean. This is part of a move to encourage use of the standard bool type over Arduino's non-standard boolean type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633

References:
- https://github.com/arduino/ArduinoCore-avr/blob/b7c607663fecc232e598f2c0acf419ceb0b7078c/cores/arduino/Stream.h#L70-L84
- https://github.com/arduino/ArduinoCore-avr/blob/b7c607663fecc232e598f2c0acf419ceb0b7078c/cores/arduino/HardwareSerial.h#L135
- https://github.com/arduino-libraries/Mouse/blob/cab14cf5c755ba606ffe3a856646312e3bbb9d4b/src/Mouse.h#L55

Related: https://github.com/arduino/reference-en/pull/300