### PR TITLE
Improve pulseInLong() description

### DIFF
--- a/Language/Functions/Advanced IO/pulseInLong.adoc
+++ b/Language/Functions/Advanced IO/pulseInLong.adoc
@@ -19,7 +19,7 @@ subCategories: [ "Advanced I/O" ]
 === Description
 `pulseInLong()` is an alternative to link:../pulsein[pulseIn()] which is better at handling long pulse and interrupt affected scenarios.
 
-Reads a pulse (either HIGH or LOW) on a pin. For example, if value is HIGH, `pulseInLong()` waits for the pin to go from `LOW` to `HIGH`, starts timing, then waits for the pin to go `LOW` and stops timing. Returns the length of the pulse in microseconds or 0 if no complete pulse was received within the timeout.
+Reads a pulse (either HIGH or LOW) on a pin. For example, if value is HIGH, `pulseInLong()` waits for the pin to go from `LOW` to `HIGH`, starts timing, then waits for the pin to go `LOW` and stops timing. Returns the length of the pulse in microseconds or gives up and returns 0 if no complete pulse was received within the timeout.
 
 The timing of this function has been determined empirically and will probably show errors in shorter pulses. Works on pulses from 10 microseconds to 3 minutes in length. This routine can be used only if interrupts are activated. Furthermore the highest resolution is obtained with large intervals.
 [%hardbreaks]

--- a/Language/Functions/Advanced IO/pulseInLong.adoc
+++ b/Language/Functions/Advanced IO/pulseInLong.adoc
@@ -17,6 +17,8 @@ subCategories: [ "Advanced I/O" ]
 
 [float]
 === Description
+`pulseInLong()` is an alternative to link:../pulsein[pulseIn()] which is better at handling long pulse and interrupt affected scenarios.
+
 Reads a pulse (either HIGH or LOW) on a pin. For example, if value is HIGH, `pulseInLong()` waits for the pin to go `HIGH`, starts timing, then waits for the pin to go `LOW` and stops timing. Returns the length of the pulse in microseconds or 0 if no complete pulse was received within the timeout.
 
 The timing of this function has been determined empirically and will probably show errors in shorter pulses. Works on pulses from 10 microseconds to 3 minutes in length. Please also note that if the pin is already high when the function is called, it will wait for the pin to go LOW and then HIGH before it starts counting. This routine can be used only if interrupts are activated. Furthermore the highest resolution is obtained with large intervals.

--- a/Language/Functions/Advanced IO/pulseInLong.adoc
+++ b/Language/Functions/Advanced IO/pulseInLong.adoc
@@ -19,7 +19,7 @@ subCategories: [ "Advanced I/O" ]
 === Description
 `pulseInLong()` is an alternative to link:../pulsein[pulseIn()] which is better at handling long pulse and interrupt affected scenarios.
 
-Reads a pulse (either HIGH or LOW) on a pin. For example, if value is HIGH, `pulseInLong()` waits for the pin to go from `LOW` to `HIGH`, starts timing, then waits for the pin to go `LOW` and stops timing. Returns the length of the pulse in microseconds or gives up and returns 0 if no complete pulse was received within the timeout.
+Reads a pulse (either `HIGH` or `LOW`) on a pin. For example, if `value` is `HIGH`, `pulseInLong()` waits for the pin to go from `LOW` to `HIGH`, starts timing, then waits for the pin to go `LOW` and stops timing. Returns the length of the pulse in microseconds or gives up and returns 0 if no complete pulse was received within the timeout.
 
 The timing of this function has been determined empirically and will probably show errors in shorter pulses. Works on pulses from 10 microseconds to 3 minutes in length. This routine can be used only if interrupts are activated. Furthermore the highest resolution is obtained with large intervals.
 [%hardbreaks]

--- a/Language/Functions/Advanced IO/pulseInLong.adoc
+++ b/Language/Functions/Advanced IO/pulseInLong.adoc
@@ -19,9 +19,9 @@ subCategories: [ "Advanced I/O" ]
 === Description
 `pulseInLong()` is an alternative to link:../pulsein[pulseIn()] which is better at handling long pulse and interrupt affected scenarios.
 
-Reads a pulse (either HIGH or LOW) on a pin. For example, if value is HIGH, `pulseInLong()` waits for the pin to go `HIGH`, starts timing, then waits for the pin to go `LOW` and stops timing. Returns the length of the pulse in microseconds or 0 if no complete pulse was received within the timeout.
+Reads a pulse (either HIGH or LOW) on a pin. For example, if value is HIGH, `pulseInLong()` waits for the pin to go from `LOW` to `HIGH`, starts timing, then waits for the pin to go `LOW` and stops timing. Returns the length of the pulse in microseconds or 0 if no complete pulse was received within the timeout.
 
-The timing of this function has been determined empirically and will probably show errors in shorter pulses. Works on pulses from 10 microseconds to 3 minutes in length. Please also note that if the pin is already high when the function is called, it will wait for the pin to go LOW and then HIGH before it starts counting. This routine can be used only if interrupts are activated. Furthermore the highest resolution is obtained with large intervals.
+The timing of this function has been determined empirically and will probably show errors in shorter pulses. Works on pulses from 10 microseconds to 3 minutes in length. This routine can be used only if interrupts are activated. Furthermore the highest resolution is obtained with large intervals.
 [%hardbreaks]
 
 


### PR DESCRIPTION
- Explain difference between pulseIn() and pulseInLong().
- Improve the explanation of pulseInLong()'s pulse handling.
- Improve documentation of how pulseInLong()'s timeout works.
- Use consistent formatting in pulseInLong() description.