### PR TITLE
Use same description as pulseInLong() for pulseIn()

### DIFF
--- a/Language/Functions/Advanced IO/pulseIn.adoc
+++ b/Language/Functions/Advanced IO/pulseIn.adoc
@@ -17,7 +17,7 @@ subCategories: [ "Advanced I/O" ]
 
 [float]
 === Description
-Reads a pulse (either HIGH or LOW) on a pin. For example, if *value* is *HIGH*, `pulseIn()` waits for the pin to go *HIGH*, starts timing, then waits for the pin to go *LOW* and stops timing. Returns the length of the pulse in microseconds. Gives up and returns 0 if no pulse starts within a specified time out.
+Reads a pulse (either `HIGH` or `LOW`) on a pin. For example, if `value` is `HIGH`, `pulseIn()` waits for the pin to go from `LOW` to `HIGH`, starts timing, then waits for the pin to go `LOW` and stops timing. Returns the length of the pulse in microseconds or gives up and returns 0 if no complete pulse was received within the timeout.
 
 The timing of this function has been determined empirically and will probably show errors in longer pulses. Works on pulses from 10 microseconds to 3 minutes in length.
 [%hardbreaks]


### PR DESCRIPTION
pulseIn() and pulseInLong() work the same and thus the descriptions should also be the same. This pull request uses the pulseInLong() description as proposed in https://github.com/arduino/reference-en/pull/371.

- Correct explanation of how the timeout works. The timeout applies to the entire duration of the function call, not only to the start of the pulse.
- Consistent formatting.

Fixes: https://github.com/arduino/Arduino/issues/7664

CC: @davidje13

References:
- https://github.com/arduino/ArduinoCore-avr/blob/master/cores/arduino/wiring_pulse.c
- https://github.com/arduino/ArduinoCore-avr/blob/master/cores/arduino/wiring_pulse.S