### PR TITLE
Improve Serial.print() page

### DIFF
--- a/Language/Functions/Communication/Serial/print.adoc
+++ b/Language/Functions/Communication/Serial/print.adoc
@@ -71,18 +71,16 @@ To send data without conversion to its representation as characters, use link:..
 [source,arduino]
 ----
 /*
-Uses a FOR loop for data and prints a number in various formats.
+Uses a for loop to print numbers in various formats.
 */
-int x = 0;    // variable
-
 void setup() {
   Serial.begin(9600);      // open the serial port at 9600 bps:
 }
 
 void loop() {
   // print labels
-  Serial.print("NO FORMAT");       // prints a label
-  Serial.print("\t");              // prints a tab
+  Serial.print("NO FORMAT");  // prints a label
+  Serial.print("\t");      // prints a tab
 
   Serial.print("DEC");
   Serial.print("\t");
@@ -94,10 +92,9 @@ void loop() {
   Serial.print("\t");
 
   Serial.print("BIN");
-  Serial.println("\t");           // carriage return after the last label 
+  Serial.println();        // carriage return after the last label
 
-  for(x=0; x< 64; x++){    // only part of the ASCII chart, change to suit
-
+  for (int x = 0; x < 64; x++) { // only part of the ASCII chart, change to suit
     // print it out in many formats:
     Serial.print(x);       // print as an ASCII-encoded decimal - same as "DEC"
     Serial.print("\t\t");  // prints two tabs to accomodate the label lenght
@@ -112,10 +109,10 @@ void loop() {
     Serial.print("\t");    // prints a tab
 
     Serial.println(x, BIN);  // print as an ASCII-encoded binary
-    //                             then adds the carriage return with "println"
+    // then adds the carriage return with "println"
     delay(200);            // delay 200 milliseconds
   }
-  Serial.println("");      // prints another carriage return
+  Serial.println();        // prints another carriage return
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Communication/Serial/print.adoc
+++ b/Language/Functions/Communication/Serial/print.adoc
@@ -35,7 +35,7 @@ You can pass flash-memory based strings to Serial.print() by wrapping them with 
 
 `Serial.print(F(“Hello World”))`
 
-To send a single byte, use link:../write[Serial.write()].
+To send data without conversion to its representation as characters, use link:../write[Serial.write()].
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Serial/print.adoc
+++ b/Language/Functions/Communication/Serial/print.adoc
@@ -27,9 +27,9 @@ An optional second parameter specifies the base (format) to use; permitted value
 * `Serial.print(78, OCT) gives "116"` +
 * `Serial.print(78, DEC) gives "78"` +
 * `Serial.print(78, HEX) gives "4E"` +
-* `Serial.println(1.23456, 0) gives "1"` +
-* `Serial.println(1.23456, 2) gives "1.23"` +
-* `Serial.println(1.23456, 4) gives "1.2346"`
+* `Serial.print(1.23456, 0) gives "1"` +
+* `Serial.print(1.23456, 2) gives "1.23"` +
+* `Serial.print(1.23456, 4) gives "1.2346"`
 
 You can pass flash-memory based strings to Serial.print() by wrapping them with link:../../../../variables/utilities/progmem[F()]. For example:
 

--- a/Language/Functions/Communication/Serial/print.adoc
+++ b/Language/Functions/Communication/Serial/print.adoc
@@ -31,7 +31,7 @@ An optional second parameter specifies the base (format) to use; permitted value
 * `Serial.println(1.23456, 2) gives "1.23"` +
 * `Serial.println(1.23456, 4) gives "1.2346"`
 
-You can pass flash-memory based strings to Serial.print() by wrapping them with F(). For example:
+You can pass flash-memory based strings to Serial.print() by wrapping them with link:../../../../variables/utilities/progmem[F()]. For example:
 
 `Serial.print(F(“Hello World”))`
 


### PR DESCRIPTION
- Link mention of `F()` to PROGMEM page.
  - Unfortunately the reference pages don't seem to provide anchors to specific page sections.
- Improve explanation of `write()` vs. `print()`.
- Don't use `Serial.println()` instead of `Serial.print()` in the usage examples.
- Improve example code.

Fixes https://github.com/arduino/Arduino/issues/1072

The only component of https://github.com/arduino/Arduino/issues/1072 this doesn't address is:
>Please revise:
"HEX (hexadecimal, or base 16)."
to read
"HEX (hexadecimal, or base 16) 1 to 4 digits.

because this information is not correct (perhaps it was back in 2012 when that issue was opened).