### PR TITLE
Add missing function links to Serial page

### DIFF
--- a/Language/Functions/Communication/Serial.adoc
+++ b/Language/Functions/Communication/Serial.adoc
@@ -55,6 +55,8 @@ link:../serial/println[println()] +
 link:../serial/read[read()] +
 link:../serial/readbytes[readBytes()] +
 link:../serial/readbytesuntil[readBytesUntil()] +
+link:../serial/readstring[readString()] +
+link:../serial/readstringuntil[readStringUntil()] +
 link:../serial/settimeout[setTimeout()] +
 link:../serial/write[write()] +
 link:../serial/serialevent[serialEvent()]


### PR DESCRIPTION
Links to readString() and readStringUntil() were missing.