### PR TITLE
Fix pgmspace link

### DIFF
--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -21,7 +21,7 @@ Store data in flash (program) memory instead of SRAM. There's a description of t
 
 The `PROGMEM` keyword is a variable modifier, it should be used only with the datatypes defined in pgmspace.h. It tells the compiler "put this information into flash memory", instead of into SRAM, where it would normally go.
 
-PROGMEM is part of the link:http://www.nongnu.org/avr-libc/user-manual/group__avr__pgmspace.html[pgmspace.h] library. It is included automatically in modern versions of the IDE, however if you are using an IDE version below 1.0 (2011), you'll first need to include the library at the top your sketch, like this:
+PROGMEM is part of the link:http://www.nongnu.org/avr-libc/user-manual/group\__avr__pgmspace.html[pgmspace.h] library. It is included automatically in modern versions of the IDE, however if you are using an IDE version below 1.0 (2011), you'll first need to include the library at the top your sketch, like this:
 
 `#include <avr/pgmspace.h>`
 [%hardbreaks]


### PR DESCRIPTION
Part of the URL was being interpreted as AsciiDoc markup, causing the link to point to:
http://www.nongnu.org/avr-libc/user-manual/group%3Cem%3Eavr%3C/em%3Epgmspace.html
instead of the correct URL:
https://www.nongnu.org/avr-libc/user-manual/group__avr__pgmspace.html
so it needed to be escaped.

Originally reported in https://github.com/arduino/reference-en/issues/312