### PR TITLE
Correct detachInterrupt() parameters documentation

### DIFF
--- a/Language/Functions/External Interrupts/detachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/detachInterrupt.adoc
@@ -23,14 +23,15 @@ Turns off the given interrupt.
 
 [float]
 === Syntax
-`detachInterrupt()` +
-`detachInterrupt(pin)` 	(Arduino Due only)
+`detachInterrupt(digitalPinToInterrupt(pin))` (Arduino AVR Boards only, recommended) +
+`detachInterrupt(interrupt)` (Arduino AVR Boards only, not recommended) +
+`detachInterrupt(pin)` (Arduino SAMD Boards, Due, 101 only)
 
 [float]
 === Parameters
 `interrupt`: the number of the interrupt to disable (see link:../attachinterrupt[attachInterrupt()] for more details).
 
-`pin`: the pin number of the interrupt to disable (Arduino Due only)
+`pin`: the pin number of the interrupt to disable
 
 [float]
 === Returns


### PR DESCRIPTION
- Remove non-existent signature without parameters.
- Document Arduino AVR Boards' `interrupt` parameter, following the style of [`attachInterrupt()`'s documentation](https://www.arduino.cc/reference/en/language/functions/external-interrupts/attachinterrupt/).
- Update the list of boards that support the `pin` parameter.

References:
- https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/WInterrupts.h#L48
- https://github.com/arduino/ArduinoCore-arc32/blob/master/cores/arduino/WInterrupts.h#L30
- https://github.com/arduino/ArduinoCore-sam/blob/master/cores/arduino/WInterrupts.h#L30
- https://github.com/arduino/ArduinoCore-avr/blob/master/cores/arduino/WInterrupts.c#L187-L275