### PR TITLE
Correct recommendations re: use of Serial.print() to debug Keyboard/Mouse emulation

### DIFF
--- a/Language/Functions/USB/Keyboard.adoc
+++ b/Language/Functions/USB/Keyboard.adoc
@@ -28,9 +28,9 @@ The library supports the use of modifier keys. Modifier keys change the behavior
 === Notes and Warnings
 These core libraries allow the 32u4 and SAMD based boards (Leonardo, Esplora, Zero, Due and MKR Family) to appear as a native Mouse and/or Keyboard to a connected computer.
 [%hardbreaks]
-*A word of caution on using the Mouse and Keyboard libraries*: if the Mouse or Keyboard library is constantly running, it will be difficult to program your board. Functions such as `Mouse.move()` and `Keyboard.print()` will move your cursor or send keystrokes to a connected computer and should only be called when you are ready to handle them. It is recommended to use a control system to turn this functionality on, like a physical switch or only responding to specific input you can control.
+*A word of caution on using the Mouse and Keyboard libraries*: if the Mouse or Keyboard library is constantly running, it will be difficult to program your board. Functions such as `Mouse.move()` and `Keyboard.print()` will move your cursor or send keystrokes to a connected computer and should only be called when you are ready to handle them. It is recommended to use a control system to turn this functionality on, like a physical switch or only responding to specific input you can control. Refer to the Mouse and Keyboard examples for some ways to handle this.
 [%hardbreaks]
-When using the Mouse or Keyboard library, it may be best to test your output first using `Serial.print()`. This way, you can be sure you know what values are being reported. Refer to the Mouse and Keyboard examples for some ways to handle this.
+When using the Mouse or Keyboard library, it may be best to test your output first using link:../../communication/serial/print[Serial.print()]. This way, you can be sure you know what values are being reported.
 
 
 // FUNCTIONS SECTION STARTS

--- a/Language/Functions/USB/Mouse.adoc
+++ b/Language/Functions/USB/Mouse.adoc
@@ -28,9 +28,9 @@ The mouse functions enable 32u4 or SAMD micro based boards to control cursor mov
 === Notes and Warnings
 These core libraries allow the 32u4 and SAMD based boards (Leonardo, Esplora, Zero, Due and MKR Family) to appear as a native Mouse and/or Keyboard to a connected computer.
 [%hardbreaks]
-*A word of caution on using the Mouse and Keyboard libraries*: if the Mouse or Keyboard library is constantly running, it will be difficult to program your board. Functions such as `Mouse.move()` and `Keyboard.print()` will move your cursor or send keystrokes to a connected computer and should only be called when you are ready to handle them. It is recommended to use a control system to turn this functionality on, like a physical switch or only responding to specific input you can control.
+*A word of caution on using the Mouse and Keyboard libraries*: if the Mouse or Keyboard library is constantly running, it will be difficult to program your board. Functions such as `Mouse.move()` and `Keyboard.print()` will move your cursor or send keystrokes to a connected computer and should only be called when you are ready to handle them. It is recommended to use a control system to turn this functionality on, like a physical switch or only responding to specific input you can control. Refer to the Mouse and Keyboard examples for some ways to handle this.
 [%hardbreaks]
-When using the Mouse or Keyboard library, it may be best to test your output first using `Serial.print()`. This way, you can be sure you know what values are being reported. Refer to the Mouse and Keyboard examples for some ways to handle this.
+When using the Mouse or Keyboard library, it may be best to test your output first using link:../../communication/serial/print[Serial.print()]. This way, you can be sure you know what values are being reported.
 [%hardbreaks]
 // FUNCTIONS SECTION STARTS
 [#functions]


### PR DESCRIPTION
The recommendation in the Keyboard and Mouse reference pages said to refer to those library's reference pages for examples of how to use Serial.print() to debug the output. However, none of the examples have such code. I believe that statement was actually intended to be put on the other recommendation to use a control system as the Keyboard/Mouse reference pages do have example code for this.

As a replacement, I added a link to the Serial.print() reference page.

Closes https://github.com/arduino/reference-en/issues/416