### PR TITLE
Use digitalPinToInterrupt() in volatile example code

### DIFF
--- a/Language/Variables/Variable Scope & Qualifiers/volatile.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/volatile.adoc
@@ -66,7 +66,7 @@ volatile byte state = LOW;
 void setup()
 {
   pinMode(pin, OUTPUT);
-  attachInterrupt(0, blink, CHANGE);
+  attachInterrupt(digitalPinToInterrupt(2), blink, CHANGE);
 }
 
 void loop()


### PR DESCRIPTION
It's recommended to always use the digitalPinToInterrupt() macro with attachInterrupt() so the example code should set a good example. This is the equivalent code for ATmega328P.

Fixes https://github.com/arduino/reference-en/issues/432

CC: @SeppPenner