### PR TITLE
Fixing sizeof doesn't highlight sizeof keyword

### DIFF
--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -12,7 +12,7 @@ subCategories: [ "Utilities" ]
 
 [float]
 === Description
-The sizeof operator returns the number of bytes in a variable type, or the number of bytes occupied by an array.
+The `sizeof` operator returns the number of bytes in a variable type, or the number of bytes occupied by an array.
 [%hardbreaks]
 
 


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-en/issues/437