### PR TITLE
Missing a break in example

### DIFF
--- a/Language/Structure/Control Structure/switchCase.adoc
+++ b/Language/Structure/Control Structure/switchCase.adoc
@@ -37,6 +37,7 @@ switch (var) {
     break;
   default:
     // statements
+    break;
 }
 ----
 


### PR DESCRIPTION
In the example, the default option is empty, it has a comment line, this would generate an error:
> expected primary-expression before the '}' token

Normally, the default option has statements, but if it is not the case, insert a break line is a solution
```
switch (estat) {
    case 'A':
      // statements
      break;
    case 'M':
      // statements
      break;
      default:
      // statements
      break;  //not necessary if you have statements
  }
```
 
