### PR TITLE
Got rid of the quote characters in visible on the Arduino website

### DIFF
--- a/Language/Functions/Characters/isAlphaNumeric.adoc
+++ b/Language/Functions/Characters/isAlphaNumeric.adoc
@@ -25,7 +25,7 @@ Analyse if a char is alphanumeric (that is a letter or a numbers). Returns true 
 === Syntax
 [source,arduino]
 ----
-`isAlphaNumeric(thisChar)`
+isAlphaNumeric(thisChar)
 ----
 
 [float]

--- a/Language/Functions/Characters/isAscii.adoc
+++ b/Language/Functions/Characters/isAscii.adoc
@@ -25,7 +25,7 @@ Analyse if a char is Ascii. Returns true if thisChar contains an Ascii character
 === Syntax
 [source,arduino]
 ----
-`isAscii(thisChar)`
+isAscii(thisChar)
 ----
 
 [float]

--- a/Language/Functions/Characters/isControl.adoc
+++ b/Language/Functions/Characters/isControl.adoc
@@ -25,7 +25,7 @@ Analyse if a char is a control character. Returns true if thisChar is a control 
 === Syntax
 [source,arduino]
 ----
-`isControl(thisChar)`
+isControl(thisChar)
 ----
 
 [float]

--- a/Language/Functions/Characters/isGraph.adoc
+++ b/Language/Functions/Characters/isGraph.adoc
@@ -25,7 +25,7 @@ Analyse if a char is printable with some content (space is printable but has no 
 === Syntax
 [source,arduino]
 ----
-`isGraph(thisChar)`
+isGraph(thisChar)
 ----
 
 [float]

--- a/Language/Functions/Characters/isLowerCase.adoc
+++ b/Language/Functions/Characters/isLowerCase.adoc
@@ -25,7 +25,7 @@ Analyse if a char is lower case (that is a letter in lower case). Returns true i
 === Syntax
 [source,arduino]
 ----
-`isLowerCase(thisChar)`
+isLowerCase(thisChar)
 ----
 
 [float]

--- a/Language/Functions/Characters/isPrintable.adoc
+++ b/Language/Functions/Characters/isPrintable.adoc
@@ -25,7 +25,7 @@ Analyse if a char is printable (that is any character that produces an output, e
 === Syntax
 [source,arduino]
 ----
-`isPrintable(thisChar)`
+isPrintable(thisChar)
 ----
 
 [float]

--- a/Language/Functions/Characters/isPunct.adoc
+++ b/Language/Functions/Characters/isPunct.adoc
@@ -25,7 +25,7 @@ Analyse if a char is punctuation (that is a comma, a semicolon, an exlamation ma
 === Syntax
 [source,arduino]
 ----
-`isPunct(thisChar)`
+isPunct(thisChar)
 ----
 
 [float]

--- a/Language/Functions/Characters/isSpace.adoc
+++ b/Language/Functions/Characters/isSpace.adoc
@@ -25,7 +25,7 @@ Analyse if a char is the space character. Returns true if thisChar contains the 
 === Syntax
 [source,arduino]
 ----
-`isSpace(thisChar)`
+isSpace(thisChar)
 ----
 
 [float]

--- a/Language/Functions/Characters/isWhitespace.adoc
+++ b/Language/Functions/Characters/isWhitespace.adoc
@@ -25,7 +25,7 @@ Returns true if thisChar contains a white space.
 [float]
 === Syntax
 [source,arduino]
-`isWhitespace(thisChar)`
+isWhitespace(thisChar)
 
 
 [float]


### PR DESCRIPTION
On the Arduino reference guide, there are quotes around the function Syntaxis, this might confuse the user, especially since it is not consistent, and present when copy pasting it.

![image](https://user-images.githubusercontent.com/877056/50292771-3b594600-0472-11e9-8c2e-35a405290145.png)

I only checked the characters functions for now