### PR TITLE
Move note about null terminator to a more appropriate location.

### DIFF
--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -66,7 +66,7 @@ void loop() {
 
 [float]
 === Notes and Warnings
-Note that `sizeof` returns the total number of bytes. So for larger variable types such as ints, the for loop would look something like this. Note also that a properly formatted string ends with the NULL symbol, which has ASCII value 0.
+Note that `sizeof` returns the total number of bytes. So for larger variable types such as ints, the for loop would look something like this. 
 
 [source,arduino]
 ----
@@ -74,6 +74,8 @@ for (i = 0; i < (sizeof(myInts)/sizeof(myInts[0])); i++) {
   // do something with myInts[i]
 }
 ----
+
+Note that a properly formatted string ends with the NULL symbol, which has ASCII value 0.
 
 --
 // HOW TO USE SECTION ENDS


### PR DESCRIPTION
It was confusing to have the note about strings sandwiched between a note about the example code and that code, which is not about strings.

Fixes https://github.com/arduino/Arduino/issues/4635#issuecomment-190979440 (second sentence)