### PR TITLE
Document size_t

### DIFF
--- a/Language/Variables/Data Types/size_t.adoc
+++ b/Language/Variables/Data Types/size_t.adoc
@@ -1,0 +1,35 @@
+---
+title: size_t
+categories: [ "Variables" ]
+subCategories: [ "Data Types" ]
+---
+
+
+
+
+
+= size_t
+
+
+// OVERVIEW SECTION STARTS
+[#overview]
+--
+
+[float]
+=== Description
+`size_t` is a data type capable of representing the size of any object in bytes. Examples of the use of `size_t` are the return type of link:../../Utilities/sizeof[sizeof()] and link:../../../Functions/Communication/Serial/print[Serial.print()].
+[%hardbreaks]
+
+--
+// OVERVIEW SECTION ENDS
+
+// SEE ALSO SECTION STARTS
+[#see_also]
+--
+
+[float]
+=== See also
+
+
+--
+// SEE ALSO SECTION ENDS


### PR DESCRIPTION
Although I don't think size_t is a type that will be commonly used by beginners in their code, some Arduino functions return size_t and that will naturally lead users to look for a size_t page in the Data Types section of the Language Reference.

Fixes https://github.com/arduino/reference-en/issues/228