### PR TITLE
Note architecture and board specificity of bitwise operators example code

### DIFF
--- a/Language/Structure/Bitwise Operators/bitwiseAnd.adoc
+++ b/Language/Structure/Bitwise Operators/bitwiseAnd.adoc
@@ -54,11 +54,11 @@ int c = a & b;  // result:    0000000001000100, or 68 in decimal.
 Each of the 16 bits in a and b are processed by using the bitwise AND, and all 16 resulting bits are stored in c, resulting in the value 01000100 in binary, which is 68 in decimal.
 [%hardbreaks]
 
-One of the most common uses of bitwise AND is to select a particular bit (or bits) from an integer value, often called masking. See below for an example
+One of the most common uses of bitwise AND is to select a particular bit (or bits) from an integer value, often called masking. See below for an example (AVR architecture specific).
 
 [source,arduino]
 ----
-PORTD = PORTD & B00000011;  // clear out bits 2 - 7, leave pins 0 and 1 untouched (xx & 11 == xx)
+PORTD = PORTD & B00000011;  // clear out bits 2 - 7, leave pins PD0 and PD1 untouched (xx & 11 == xx)
 ----
 
 --

--- a/Language/Structure/Bitwise Operators/bitwiseOr.adoc
+++ b/Language/Structure/Bitwise Operators/bitwiseOr.adoc
@@ -53,8 +53,10 @@ One of the most common uses of the Bitwise OR is to set multiple bits in a bit-p
 
 [source,arduino]
 ----
-DDRD = DDRD | B11111100; // set direction bits for pins 2 to 7, leave 0 and 1 untouched (xx | 00 == xx)
-// same as pinMode(pin, OUTPUT) for pins 2 to 7
+// Note: This code is AVR architecture specific
+// set direction bits for pins 2 to 7, leave PD0 and PD1 untouched (xx | 00 == xx)
+// same as pinMode(pin, OUTPUT) for pins 2 to 7 on Uno or Nano
+DDRD = DDRD | B11111100;
 ----
 
 --

--- a/Language/Structure/Bitwise Operators/bitwiseXor.adoc
+++ b/Language/Structure/Bitwise Operators/bitwiseXor.adoc
@@ -49,19 +49,19 @@ int z = x ^ y;  // binary: 0110, or decimal 6
 ----
 [%hardbreaks]
 
-The ^ operator is often used to toggle (i.e. change from 0 to 1, or 1 to 0) some of the bits in an integer expression. In a bitwise XOR operation if there is a 1 in the mask bit, that bit is inverted; if there is a 0, the bit is not inverted and stays the same. Below is a program to blink digital pin 5.
+The ^ operator is often used to toggle (i.e. change from 0 to 1, or 1 to 0) some of the bits in an integer expression. In a bitwise XOR operation if there is a 1 in the mask bit, that bit is inverted; if there is a 0, the bit is not inverted and stays the same.
 
 [source,arduino]
 ----
-// Blink_Pin_5
-// demo for Exclusive OR
+// Note: This code uses registers specific to AVR microcontrollers (Uno, Nano, Leonardo, Mega, etc.)
+// it will not compile for other architectures
 void setup(){
-DDRD = DDRD | B00100000; // set digital pin five as OUTPUT
+DDRB = DDRB | B00100000; // set PB5 (pin 13 on Uno/Nano, pin 9 on Leonardo/Micro, pin 11 on Mega) as OUTPUT
 Serial.begin(9600);
 }
 
 void loop(){
-PORTD = PORTD ^ B00100000;  // invert bit 5 (digital pin 5), leave others untouched
+PORTB = PORTB ^ B00100000;  // invert PB5, leave others untouched
 delay(100);
 }
 ----


### PR DESCRIPTION
Previously, it was not explained that the examples use AVR-specific register names and will affect different pins depending on which board is used.

Fixes https://github.com/arduino/reference-en/issues/235