### PR TITLE
Remove unnecessary "See Also" link

### DIFF
--- a/Language/Variables/Data Types/boolean.adoc
+++ b/Language/Variables/Data Types/boolean.adoc
@@ -36,7 +36,6 @@ subCategories: [ "Data Types" ]
 === See also
 
 [role="language"]
-* #LANGUAGE# link:../../../variables/data-types/bool/[bool]
 
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
"See Also" links for all pages in the same section are automatically added so this link only makes the reference more difficult to maintain.