### PR TITLE
Document String variable in Parameters section of String functions

### DIFF
--- a/Language/Variables/Data Types/String/Functions/c_str.adoc
+++ b/Language/Variables/Data Types/String/Functions/c_str.adoc
@@ -28,7 +28,7 @@ Converts the contents of a String as a C-style, null-terminated string. Note tha
 
 [float]
 === Parameters
-none
+`myString`: a variable of type String
 
 [float]
 === Returns

--- a/Language/Variables/Data Types/String/Functions/concat.adoc
+++ b/Language/Variables/Data Types/String/Functions/concat.adoc
@@ -28,6 +28,8 @@ Appends the parameter to a String.
 
 [float]
 === Parameters
+`myString`: a variable of type String
+
 `parameter`: *Allowed types are* String, string, char, byte, int, unsigned int, long, unsigned long, float, double, __FlashStringHelper(F() macro).
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/remove.adoc
+++ b/Language/Variables/Data Types/String/Functions/remove.adoc
@@ -29,6 +29,8 @@ Modify in place a String removing chars from the provided index to the end of th
 
 [float]
 === Parameters
+`myString`: a variable of type String
+
 `index`: a variable of type unsigned int
 
 `count`: a variable of type unsigned int

--- a/Language/Variables/Data Types/String/Functions/reserve.adoc
+++ b/Language/Variables/Data Types/String/Functions/reserve.adoc
@@ -28,6 +28,8 @@ The String reserve() function allows you to allocate a buffer in memory for mani
 
 [float]
 === Parameters
+`myString`: a variable of type String
+
 `size`: unsigned int declaring the number of bytes in memory to save for String manipulation 
 
 


### PR DESCRIPTION
Some of the reference pages were missing this from the Parameters section.