### PR TITLE
Consistently document inheritance from Stream class

### DIFF
--- a/Language/Functions/Communication/Serial/available.adoc
+++ b/Language/Functions/Communication/Serial/available.adoc
@@ -11,7 +11,9 @@ title: Serial.available()
 
 [float]
 === Description
-Get the number of bytes (characters) available for reading from the serial port. This is data that's already arrived and stored in the serial receive buffer (which holds 64 bytes). `available()` inherits from the Stream utility class.
+Get the number of bytes (characters) available for reading from the serial port. This is data that's already arrived and stored in the serial receive buffer (which holds 64 bytes).
+
+`Serial.available()` inherits from the link:../../stream[Stream] utility class.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Serial/parseInt.adoc
+++ b/Language/Functions/Communication/Serial/parseInt.adoc
@@ -14,7 +14,9 @@ title: Serial.parseInt()
 
 [float]
 === Description
-Looks for the next valid integer in the incoming serial `stream.parseInt()` inherits from the link:../../stream[Stream] utility class.
+Looks for the next valid integer in the incoming serial.
+
+`Serial.parseInt()` inherits from the link:../../stream[Stream] utility class.
 
 
 In particular:

--- a/Language/Functions/Communication/Serial/peek.adoc
+++ b/Language/Functions/Communication/Serial/peek.adoc
@@ -14,7 +14,9 @@ title: Serial.peek()
 
 [float]
 === Description
-Returns the next byte (character) of incoming serial data without removing it from the internal serial buffer. That is, successive calls to `peek()` will return the same character, as will the next call to `read()`. `peek()` inherits from the link:../../stream[Stream] utility class.
+Returns the next byte (character) of incoming serial data without removing it from the internal serial buffer. That is, successive calls to `peek()` will return the same character, as will the next call to `read()`.
+
+`Serial.peek()` inherits from the link:../../stream[Stream] utility class.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Serial/read.adoc
+++ b/Language/Functions/Communication/Serial/read.adoc
@@ -14,7 +14,9 @@ title: Serial.read()
 
 [float]
 === Description
-Reads incoming serial data. read() inherits from the link:../../stream[Stream] utility class.
+Reads incoming serial data.
+
+`Serial.read()` inherits from the link:../../stream[Stream] utility class.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Serial/readString.adoc
+++ b/Language/Functions/Communication/Serial/readString.adoc
@@ -16,8 +16,7 @@ title: Serial.readString()
 === Description
 `Serial.readString()` reads characters from the serial buffer into a String. The function terminates if it times out (see link:../settimeout[setTimeout()]).
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
-
+`Serial.readString()` inherits from the link:../../stream[Stream] utility class.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Serial/readStringUntil.adoc
+++ b/Language/Functions/Communication/Serial/readStringUntil.adoc
@@ -16,8 +16,7 @@ title: Serial.readStringUntil()
 === Description
 `readStringUntil()` reads characters from the serial buffer into a String. The function terminates if it times out (see link:../settimeout[setTimeout()]).
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
-
+`Serial.readStringUntil()` inherits from the link:../../stream[Stream] utility class.
 [%hardbreaks]
 
 


### PR DESCRIPTION
A standard style was established in the other Serial reference pages, but not followed by all of them.