### PR TITLE
Add warnings about doing operations inside macro parameters

### DIFF
--- a/Language/Functions/Math/constrain.adoc
+++ b/Language/Functions/Math/constrain.adoc
@@ -60,6 +60,24 @@ The code limits the sensor values to between 10 to 150.
 sensVal = constrain(sensVal, 10, 150);    // limits range of sensor values to between 10 and 150
 ----
 
+[float]
+=== Notes and Warnings
+Because of the way the `constrain()` function is implemented, avoid using other functions inside the brackets, it may lead to incorrect results.
+
+This code will yield incorrect results:
+[source,arduino]
+----
+int constrainedInput = constrain(Serial.parseInt(), minimumValue, maximumValue);   // avoid this
+----
+
+Use this instead:
+[source,arduino]
+----
+int input = Serial.parseInt();  // keep other operations outside the constrain function
+int constrainedInput = constrain(input, minimumValue, maximumValue);
+----
+[%hardbreaks]
+
 --
 // HOW TO USE SECTION ENDS
 

--- a/Language/Functions/Math/sq.adoc
+++ b/Language/Functions/Math/sq.adoc
@@ -38,6 +38,32 @@ The square of the number. (double)
 // OVERVIEW SECTION ENDS
 
 
+// HOW TO USE SECTION STARTS
+[#howtouse]
+--
+
+[float]
+=== Notes and Warnings
+Because of the way the `sq()` function is implemented, avoid using other functions inside the brackets, it may lead to incorrect results.
+
+This code will yield incorrect results:
+[source,arduino]
+----
+int inputSquared = sq(Serial.parseInt()); // avoid this
+----
+
+Use this instead:
+[source,arduino]
+----
+int input = Serial.parseInt();  // keep other operations outside the sq function
+int inputSquared = sq(input);
+----
+[%hardbreaks]
+
+--
+// HOW TO USE SECTION ENDS
+
+
 // SEE ALSO SECTION
 [#see_also]
 --


### PR DESCRIPTION
The way these macros are written, causes operations done within the parameters to be repeated when the macro runs.

Although warnings were already added to `max()` and `min()`, they were still missing from `constrain()` and `sq()`.