### PR TITLE
Emphasize that IO functions take Arduino pin numbers

### DIFF
--- a/Language/Functions/Advanced IO/noTone.adoc
+++ b/Language/Functions/Advanced IO/noTone.adoc
@@ -27,7 +27,7 @@ Stops the generation of a square wave triggered by `tone()`. Has no effect if no
 
 [float]
 === Parameters
-`pin`: the pin on which to stop generating the tone
+`pin`: the Arduino pin on which to stop generating the tone
 
 [float]
 === Returns

--- a/Language/Functions/Advanced IO/pulseIn.adoc
+++ b/Language/Functions/Advanced IO/pulseIn.adoc
@@ -31,7 +31,7 @@ The timing of this function has been determined empirically and will probably sh
 
 [float]
 === Parameters
-`pin`: the number of the pin on which you want to read the pulse. Allowed data types: `int`. +
+`pin`: the number of the Arduino pin on which you want to read the pulse. Allowed data types: `int`. +
 `value`: type of pulse to read: either link:../../../variables/constants/constants/[HIGH] or link:../../../variables/constants/constants/[LOW]. Allowed data types: `int`. +
 `timeout` (optional): the number of microseconds to wait for the pulse to start; default is one second. Allowed data types: `unsigned long`.
 

--- a/Language/Functions/Advanced IO/pulseInLong.adoc
+++ b/Language/Functions/Advanced IO/pulseInLong.adoc
@@ -33,7 +33,7 @@ The timing of this function has been determined empirically and will probably sh
 
 [float]
 === Parameters
-`pin`: the number of the pin on which you want to read the pulse. Allowed data types: `int`. +
+`pin`: the number of the Arduino pin on which you want to read the pulse. Allowed data types: `int`. +
 `value`: type of pulse to read: either link:../../../variables/constants/constants/[HIGH] or link:../../../variables/constants/constants/[LOW]. Allowed data types: `int`. +
 `timeout` (optional): the number of microseconds to wait for the pulse to start; default is one second. Allowed data types: `unsigned long`.
 

--- a/Language/Functions/Advanced IO/tone.adoc
+++ b/Language/Functions/Advanced IO/tone.adoc
@@ -35,7 +35,7 @@ It is not possible to generate tones lower than 31Hz. For technical details, see
 
 [float]
 === Parameters
-`pin`: the pin on which to generate the tone. +
+`pin`: the Arduino pin on which to generate the tone. +
 `frequency`: the frequency of the tone in hertz. Allowed data types: `unsigned int`. +
 `duration`: the duration of the tone in milliseconds (optional). Allowed data types: `unsigned long`.
 

--- a/Language/Functions/Analog IO/analogWrite.adoc
+++ b/Language/Functions/Analog IO/analogWrite.adoc
@@ -33,7 +33,7 @@ The `analogWrite` function has nothing to do with the analog pins or the `analog
 
 [float]
 === Parameters
-`pin`: the pin to write to. Allowed data types: `int`. +
+`pin`: the Arduino pin to write to. Allowed data types: `int`. +
 `value`: the duty cycle: between 0 (always off) and 255 (always on). Allowed data types: `int`.
 
 

--- a/Language/Functions/Digital IO/digitalRead.adoc
+++ b/Language/Functions/Digital IO/digitalRead.adoc
@@ -28,7 +28,7 @@ Reads the value from a specified digital pin, either `HIGH` or `LOW`.
 
 [float]
 === Parameters
-`pin`: the number of the digital pin you want to read
+`pin`: the Arduino pin number you want to read
 
 
 [float]

--- a/Language/Functions/Digital IO/digitalWrite.adoc
+++ b/Language/Functions/Digital IO/digitalWrite.adoc
@@ -35,7 +35,7 @@ If you do not set the `pinMode()` to `OUTPUT`, and connect an LED to a pin, when
 
 [float]
 === Parameters
-`pin`: the pin number. +
+`pin`: the Arduino pin number. +
 `value`: `HIGH` or `LOW`.
 
 

--- a/Language/Functions/Digital IO/pinMode.adoc
+++ b/Language/Functions/Digital IO/pinMode.adoc
@@ -30,7 +30,7 @@ As of Arduino 1.0.1, it is possible to enable the internal pullup resistors with
 
 [float]
 === Parameters
-`pin`: the number of the pin whose mode you wish to set. +
+`pin`: the Arduino pin number to set the mode of. +
 `mode`: `INPUT`, `OUTPUT`, or `INPUT_PULLUP`. See the http://arduino.cc/en/Tutorial/DigitalPins[Digital Pins] page for a more complete description of the functionality.
 
 

--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -65,7 +65,7 @@ For more information on interrupts, see http://gammon.com.au/interrupts[Nick Gam
 [float]
 === Parameters
 `interrupt`: the number of the interrupt. Allowed data types: `int`. +
-`pin`: the pin number. +
+`pin`: the Arduino pin number. +
 `ISR`: the ISR to call when the interrupt occurs; this function must take no parameters and return nothing. This function is sometimes referred to as an interrupt service routine. +
 `mode`: defines when the interrupt should be triggered. Four constants are predefined as valid values: +
 

--- a/Language/Functions/External Interrupts/detachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/detachInterrupt.adoc
@@ -31,7 +31,7 @@ Turns off the given interrupt.
 [float]
 === Parameters
 `interrupt`: the number of the interrupt to disable (see link:../attachinterrupt[attachInterrupt()] for more details). +
-`pin`: the pin number of the interrupt to disable
+`pin`: the Arduino pin number of the interrupt to disable
 
 
 [float]


### PR DESCRIPTION
It's fairly common for users dabbling with bare microcontroller chips (e.g. "Arduino on a breadboard") to think that they can pass either the port/bit pin notation (e.g. PB5) or physical chip pin numbers to the Arduino IO functions.

These changes are intended to emphasize that these functions only accept Arduino pin numbers as their pin parameter, without complicating the documentation for the users of standard Arduino boards.

I'd like to eventually add a simple explanation of Arduino pin numbers to the "[Digital Pins](https://www.arduino.cc/en/Tutorial/DigitalPins)" tutorial, and perhaps the "[Analog Pins](https://www.arduino.cc/en/Tutorial/AnalogInputPins)" tutorial as well.

---
Reference:
- https://github.com/arduino/Arduino/issues/8383#issuecomment-453788794
- http://forum.arduino.cc/index.php?topic=596540
- http://forum.arduino.cc/index.php?topic=597029
- https://github.com/SpenceKonde/ATTinyCore/issues/287
- https://forum.arduino.cc/index.php?topic=618488