### PR TITLE
Document compound remainder

### DIFF
--- a/Language/Structure/Compound Operators/compoundRemainder.adoc
+++ b/Language/Structure/Compound Operators/compoundRemainder.adoc
@@ -1,0 +1,80 @@
+---
+title: "%="
+title_expanded: compound remainder
+categories: [ "Structure" ]
+subCategories: [ "Compound Operators" ]
+---
+
+
+
+
+
+= %= Compound Remainder
+
+
+// OVERVIEW SECTION STARTS
+[#overview]
+--
+
+[float]
+=== Description
+This is a convenient shorthand to calculate the remainder when one integer is divided by another and assign it back to the variable the calculation was done on.
+[%hardbreaks]
+
+
+[float]
+=== Syntax
+[source,arduino]
+----
+x %= divisor;   // equivalent to the expression x = x % divisor;
+----
+
+[float]
+=== Parameters
+`x`: variable. *Allowed data types:* int +
+`divisor`: *non zero* variable or constant. *Allowed data types:* int
+
+--
+// OVERVIEW SECTION ENDS
+
+
+
+// HOW TO USE SECTION STARTS
+[#howtouse]
+--
+
+[float]
+=== Example Code
+
+[source,arduino]
+----
+int x = 7;
+x %= 5;    // x now contains 2
+----
+[%hardbreaks]
+
+[float]
+=== Notes and Warnings
+1. The compound remainder operator does not work on floats.
+
+2. If the *first* operand is negative, the result is negative (or zero).
+Therefore, the result of `x %= 10` will not always be between 0 and 9 if `x` can be negative.
+[%hardbreaks]
+
+--
+// HOW TO USE SECTION ENDS
+
+
+
+//SEE ALSO SECTION BEGINS
+[#see_also]
+--
+
+[float]
+=== See also
+
+[role="language"]
+* #LANGUAGE#  link:../../arithmetic-operators/remainder[Remainder]
+
+--
+// SEE ALSO SECTION ENDS


### PR DESCRIPTION
This fixes a regression of https://github.com/arduino/Arduino/issues/3723 caused by the switch to the new Language Reference system.

Originally, %= was referred to as "compound modulo". However, since that time the decision was made to rename the modulo reference page to "remainder" (https://github.com/arduino/reference-en/pull/350) so I have followed that precedent in this page.
