### PR TITLE
Add Yun to the list of the boards serialEvent() doesn't work for

### DIFF
--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -61,7 +61,7 @@ Nothing
 
 [float]
 === Notes and Warnings
-`serialEvent()` doesn't work on the Leonardo or Micro.
+`serialEvent()` doesn't work on the Leonardo, Micro, or Yún.
 
 `serialEvent()` and `serialEvent1()` don't work on the Arduino SAMD Boards
 


### PR DESCRIPTION
I had originally left the Yun off the list because it's retired and I figure "Leonardo and Micro" can represent all ATmega32U4-based boards. However, there is an issue report specifically requesting that this board be added to the list so I'll add it in just to be able to conclusively close that issue.

I don't think it does any harm to be a bit more verbose, since this list is in the "Notes and Warnings" section.

In combination with https://github.com/arduino/reference-en/pull/506, fixes https://github.com/arduino/Arduino/issues/4328