### PR TITLE
Document the limits of serial transmission asyncronicity

### DIFF
--- a/Language/Functions/Communication/Serial/print.adoc
+++ b/Language/Functions/Communication/Serial/print.adoc
@@ -121,7 +121,7 @@ void loop() {
 
 [float]
 === Notes and Warnings
-As of version 1.0, serial transmission is asynchronous; `Serial.print()` will return before any characters are transmitted.
+For information on the asyncronicity of `Serial.print()`, see the Notes and Warnings section of the link:../write#howtouse[Serial.write() reference page].
 
 --
 // HOW TO USE SECTION ENDS

--- a/Language/Functions/Communication/Serial/println.adoc
+++ b/Language/Functions/Communication/Serial/println.adoc
@@ -80,6 +80,11 @@ void loop() {
   delay(10);
 }
 ----
+[%hardbreaks]
+
+[float]
+=== Notes and Warnings
+For information on the asyncronicity of `Serial.println()`, see the Notes and Warnings section of the link:../write#howtouse[Serial.write() reference page].
 
 --
 // HOW TO USE SECTION ENDS

--- a/Language/Functions/Communication/Serial/write.adoc
+++ b/Language/Functions/Communication/Serial/write.adoc
@@ -66,6 +66,11 @@ void loop(){
    int bytesSent = Serial.write(“hello”); //send the string “hello” and return the length of the string.
 }
 ----
+[%hardbreaks]
+
+[float]
+=== Notes and Warnings
+As of Arduino IDE 1.0, serial transmission is asynchronous. If there is enough empty space in the transmit buffer, `Serial.write()` will return before any characters are transmitted over serial. If the transmit buffer is full then `Serial.write()` will block until there is enough space in the buffer. To avoid blocking calls to `Serial.write()`, you can first check the amount of free space in the transmit buffer using link:../availableforwrite[availableForWrite()].
 
 --
 // HOW TO USE SECTION ENDS


### PR DESCRIPTION
`Serial.write()`, `Serial.print()`, `Serial.println()` are asynchronous only if there is enough free space in the transmit buffer.

Since `write()` is the base function for transmit operations, I moved the documentation to that page and linked to it from `Serial.print()` and `Serial.println()`. Since this is advanced information, I think this approach was worthwhile in the interest of avoiding duplicate content, even at the expense of making this specific part of the documentation slightly less user friendly due to the necessity of following a link. I think this may actually make the documentation more beginner friendly because it hides the information that is of no interest to a beginner in a reference page that they are less likely to read, while still making it quite accessible if they actually do want to know.

Fixes https://github.com/arduino/Arduino/issues/5408