### PR TITLE
Add note that the Nano, et al. A6 and A7 can not be used as digital pins

### DIFF
--- a/Language/Functions/Digital IO/digitalRead.adoc
+++ b/Language/Functions/Digital IO/digitalRead.adoc
@@ -73,7 +73,7 @@ void loop()
 === Notes and Warnings
 If the pin isn't connected to anything, digitalRead() can return either HIGH or LOW (and this can change randomly).
 
-The analog input pins can be used as digital pins, referred to as A0, A1, etc.
+The analog input pins can be used as digital pins, referred to as A0, A1, etc. The exception is the Arduino Nano, Pro Mini, and Mini's A6 and A7 pins, which can only be used as analog inputs.
 
 --
 // HOW TO USE SECTION ENDS


### PR DESCRIPTION
I already did this for `digitalWrite()` in https://github.com/arduino/reference-en/pull/477, but forgot to do the same for `digitalRead()`.