### PR TITLE
Update/correct attach/detachInterrupts pin parameter compatibility documentation

### DIFF
--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -59,13 +59,13 @@ For more information on interrupts, see http://gammon.com.au/interrupts[Nick Gam
 === Syntax
 `attachInterrupt(digitalPinToInterrupt(pin), ISR, mode);` (recommended) +
 `attachInterrupt(interrupt, ISR, mode);` (not recommended) +
-`attachInterrupt(pin, ISR, mode);` (not recommended Arduino Due, Zero, MKR1000, 101 only)
+`attachInterrupt(pin, ISR, mode);` (Not recommended. Arduino SAMD Boards, Uno WiFi Rev2, Due, 101 only)
 
 
 [float]
 === Parameters
 `interrupt`: the number of the interrupt (`int`) +
-`pin`: the pin number _(Arduino Due, Zero, MKR1000 only)_ +
+`pin`: the pin number +
 `ISR`: the ISR to call when the interrupt occurs; this function must take no parameters and return nothing. This function is sometimes referred to as an interrupt service routine. +
 `mode`: defines when the interrupt should be triggered. Four constants are predefined as valid values: +
 

--- a/Language/Functions/External Interrupts/detachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/detachInterrupt.adoc
@@ -23,9 +23,9 @@ Turns off the given interrupt.
 
 [float]
 === Syntax
-`detachInterrupt(digitalPinToInterrupt(pin))` (Arduino AVR Boards only, recommended) +
-`detachInterrupt(interrupt)` (Arduino AVR Boards only, not recommended) +
-`detachInterrupt(pin)` (Arduino SAMD Boards, Due, 101 only)
+`detachInterrupt(digitalPinToInterrupt(pin))` (recommended) +
+`detachInterrupt(interrupt)` (not recommended) +
+`detachInterrupt(pin)` (Not recommended. Arduino SAMD Boards, Uno WiFi Rev2, Due, 101 only)
 
 [float]
 === Parameters


### PR DESCRIPTION
- Add Uno WiFi Rev2 to the list of boards compatible with the `pin` parameter
- Remove incorrect information about `detachInterrupt`'s first two signatures being AVR only
- Make documentation style consistent between the two files
- Remove duplicate content, which makes maintenance of the content more difficult without providing any significant benefit