### PR TITLE
Correct char documentation re: size and signedness

### DIFF
--- a/Language/Variables/Data Types/char.adoc
+++ b/Language/Variables/Data Types/char.adoc
@@ -17,11 +17,11 @@ subCategories: [ "Data Types" ]
 
 [float]
 === Description
-A data type that takes up 1 byte of memory that stores a character value. Character literals are written in single quotes, like this: 'A' (for multiple characters - strings - use double quotes: "ABC").
+A data type used to store a character value. Character literals are written in single quotes, like this: 'A' (for multiple characters - strings - use double quotes: "ABC").
 
 Characters are stored as numbers however. You can see the specific encoding in the link:https://www.arduino.cc/en/Reference/ASCIIchart[ASCII chart]. This means that it is possible to do arithmetic on characters, in which the ASCII value of the character is used (e.g. 'A' + 1 has the value 66, since the ASCII value of the capital letter A is 65). See link:../../../functions/communication/serial/println[`Serial.println`] reference for more on how characters are translated to numbers.
 
-The char datatype is a signed type, meaning that it encodes numbers from -128 to 127. For an unsigned, one-byte (8 bit) data type, use the _byte_ data type.
+The size of the `char` datatype is at least 8 bits. It's recommended to only use `char` for storing characters. For an unsigned, one-byte (8 bit) data type, use the link:../byte[byte] data type.
 [%hardbreaks]
 
 --


### PR DESCRIPTION
Size and signedness of char documentation may change from one architecture to another. The previous documentation was correct for AVR, but not for SAMD (and other architectures).

Here, I've implemented the solution recommended by cmaglie at:
https://github.com/arduino/Arduino/issues/4525#issuecomment-314106836

Reported at:
- https://github.com/arduino/Arduino/issues/3801
- https://github.com/arduino/Arduino/issues/4525#issuecomment-186862231
- https://forum.arduino.cc/index.php?topic=399332
- http://forum.arduino.cc/index.php?topic=400909