### PR TITLE
Correct documentation of word data type's size

### DIFF
--- a/Language/Variables/Data Types/word.adoc
+++ b/Language/Variables/Data Types/word.adoc
@@ -17,7 +17,7 @@ subCategories: [ "Data Types" ]
 
 [float]
 === Description
-A word stores a 16-bit unsigned number, from 0 to 65535. Same as an unsigned int.
+A word can store an unsigned number of at least 16 bits (from 0 to 65535).
 [%hardbreaks]
 
 --


### PR DESCRIPTION
The size of word can change from one architecture to another. The previous documentation was correct for AVR but not for SAMD (and other architectures).

Here, I've implemented the solution recommended by cmaglie at:
https://github.com/arduino/Arduino/issues/4525#issuecomment-314106836

Reported at:
- https://github.com/arduino/Arduino/issues/3801
- https://github.com/arduino/Arduino/issues/4525#issuecomment-186862231