### PR TITLE
Use consistent formatting of all code

### DIFF
--- a/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Single_Entity.adoc
+++ b/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Single_Entity.adoc
@@ -76,13 +76,11 @@ int ledPin = 9;      // LED connected to digital pin 9
 int analogPin = 3;   // potentiometer connected to analog pin 3
 int val = 0;         // variable to store the read value
 
-void setup()
-{
+void setup() {
   pinMode(ledPin, OUTPUT);   // sets the pin as output
 }
 
-void loop()
-{
+void loop() {
   val = analogRead(analogPin);   // read the input pin
   analogWrite(ledPin, val / 4);  // analogRead values go from 0 to 1023, analogWrite values from 0 to 255
 }

--- a/Language/Functions/Advanced IO/pulseIn.adoc
+++ b/Language/Functions/Advanced IO/pulseIn.adoc
@@ -60,14 +60,12 @@ The example prints the time duration of a pulse on pin 7.
 int pin = 7;
 unsigned long duration;
 
-void setup()
-{
+void setup() {
   Serial.begin(9600);
   pinMode(pin, INPUT);
 }
 
-void loop()
-{
+void loop() {
   duration = pulseIn(pin, HIGH);
   Serial.println(duration);
 }

--- a/Language/Functions/Analog IO/analogRead.adoc
+++ b/Language/Functions/Analog IO/analogRead.adoc
@@ -65,19 +65,17 @@ The code reads the voltage on analogPin and displays it.
 
 [source,arduino]
 ----
-int analogPin = A3;     // potentiometer wiper (middle terminal) connected to analog pin 3
-                       // outside leads to ground and +5V
-int val = 0;           // variable to store the value read
+int analogPin = A3; // potentiometer wiper (middle terminal) connected to analog pin 3
+                    // outside leads to ground and +5V
+int val = 0;  // variable to store the value read
 
-void setup()
-{
-  Serial.begin(9600);              //  setup serial
+void setup() {
+  Serial.begin(9600);           //  setup serial
 }
 
-void loop()
-{
-  val = analogRead(analogPin);     // read the input pin
-  Serial.println(val);             // debug value
+void loop() {
+  val = analogRead(analogPin);  // read the input pin
+  Serial.println(val);          // debug value
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Analog IO/analogWrite.adoc
+++ b/Language/Functions/Analog IO/analogWrite.adoc
@@ -62,15 +62,13 @@ int ledPin = 9;      // LED connected to digital pin 9
 int analogPin = 3;   // potentiometer connected to analog pin 3
 int val = 0;         // variable to store the read value
 
-void setup()
-{
-  pinMode(ledPin, OUTPUT);   // sets the pin as output
+void setup() {
+  pinMode(ledPin, OUTPUT);  // sets the pin as output
 }
 
-void loop()
-{
-  val = analogRead(analogPin);   // read the input pin
-  analogWrite(ledPin, val / 4);  // analogRead values go from 0 to 1023, analogWrite values from 0 to 255
+void loop() {
+  val = analogRead(analogPin);  // read the input pin
+  analogWrite(ledPin, val / 4); // analogRead values go from 0 to 1023, analogWrite values from 0 to 255
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Characters/isAlpha.adoc
+++ b/Language/Functions/Characters/isAlpha.adoc
@@ -50,15 +50,12 @@ isAlpha(thisChar)
 
 [source,arduino]
 ----
-if (isAlpha(myChar))      // tests if myChar is a letter
-{
-	Serial.println("The character is a letter");
+if (isAlpha(myChar)) {  // tests if myChar is a letter
+  Serial.println("The character is a letter");
 }
-else
-{
-	Serial.println("The character is not a letter");
+else {
+  Serial.println("The character is not a letter");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isAlphaNumeric.adoc
+++ b/Language/Functions/Characters/isAlphaNumeric.adoc
@@ -50,15 +50,12 @@ isAlphaNumeric(thisChar)
 
 [source,arduino]
 ----
-if (isAlphaNumeric(myChar))      // tests if myChar isa letter or a number
-{
-	Serial.println("The character is alphanumeric");
+if (isAlphaNumeric(myChar)) { // tests if myChar isa letter or a number
+  Serial.println("The character is alphanumeric");
 }
-else
-{
-	Serial.println("The character is not alphanumeric");
+else {
+  Serial.println("The character is not alphanumeric");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isAscii.adoc
+++ b/Language/Functions/Characters/isAscii.adoc
@@ -50,15 +50,12 @@ isAscii(thisChar)
 
 [source,arduino]
 ----
-if (isAscii(myChar))      // tests if myChar is an Ascii character
-{
-	Serial.println("The character is Ascii");
+if (isAscii(myChar)) {  // tests if myChar is an Ascii character
+  Serial.println("The character is Ascii");
 }
-else
-{
-	Serial.println("The character is not Ascii");
+else {
+  Serial.println("The character is not Ascii");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isControl.adoc
+++ b/Language/Functions/Characters/isControl.adoc
@@ -50,15 +50,12 @@ isControl(thisChar)
 
 [source,arduino]
 ----
-if (isControl(myChar))      // tests if myChar is a control character
-{
-	Serial.println("The character is a control character");
+if (isControl(myChar)) {  // tests if myChar is a control character
+  Serial.println("The character is a control character");
 }
-else
-{
-	Serial.println("The character is not a control character");
+else {
+  Serial.println("The character is not a control character");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isDigit.adoc
+++ b/Language/Functions/Characters/isDigit.adoc
@@ -50,15 +50,12 @@ isDigit(thisChar)
 
 [source,arduino]
 ----
-if (isDigit(myChar))      // tests if myChar is a digit
-{
-	Serial.println("The character is a number");
+if (isDigit(myChar)) {  // tests if myChar is a digit
+  Serial.println("The character is a number");
 }
-else
-{
-	Serial.println("The character is not a number");
+else {
+  Serial.println("The character is not a number");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isGraph.adoc
+++ b/Language/Functions/Characters/isGraph.adoc
@@ -50,15 +50,12 @@ isGraph(thisChar)
 
 [source,arduino]
 ----
-if (isGraph(myChar))      // tests if myChar is a printable character but not a blank space.
-{
-	Serial.println("The character is printable");
+if (isGraph(myChar)) {  // tests if myChar is a printable character but not a blank space.
+  Serial.println("The character is printable");
 }
-else
-{
-	Serial.println("The character is not printable");
+else {
+  Serial.println("The character is not printable");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isHexadecimalDigit.adoc
+++ b/Language/Functions/Characters/isHexadecimalDigit.adoc
@@ -52,15 +52,12 @@ isHexadecimalDigit(thisChar)
 
 [source,arduino]
 ----
-if (isHexadecimalDigit(myChar))      // tests if myChar is an hexadecimal digit
-{
-	Serial.println("The character is an hexadecimal digit");
+if (isHexadecimalDigit(myChar)) { // tests if myChar is an hexadecimal digit
+  Serial.println("The character is an hexadecimal digit");
 }
-else
-{
-	Serial.println("The character is not an hexadecimal digit");
+else {
+  Serial.println("The character is not an hexadecimal digit");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isLowerCase.adoc
+++ b/Language/Functions/Characters/isLowerCase.adoc
@@ -50,15 +50,12 @@ isLowerCase(thisChar)
 
 [source,arduino]
 ----
-if (isLowerCase(myChar))      // tests if myChar is a lower case letter
-{
-	Serial.println("The character is lower case");
+if (isLowerCase(myChar)) {  // tests if myChar is a lower case letter
+  Serial.println("The character is lower case");
 }
-else
-{
-	Serial.println("The character is not lower case");
+else {
+  Serial.println("The character is not lower case");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isPrintable.adoc
+++ b/Language/Functions/Characters/isPrintable.adoc
@@ -50,15 +50,12 @@ isPrintable(thisChar)
 
 [source,arduino]
 ----
-if (isPrintable(myChar))      // tests if myChar is printable char
-{
-	Serial.println("The character is printable");
+if (isPrintable(myChar)) {  // tests if myChar is printable char
+  Serial.println("The character is printable");
 }
-else
-{
-	Serial.println("The character is not printable");
+else {
+  Serial.println("The character is not printable");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isPunct.adoc
+++ b/Language/Functions/Characters/isPunct.adoc
@@ -50,15 +50,12 @@ isPunct(thisChar)
 
 [source,arduino]
 ----
-if (isPunct(myChar))      // tests if myChar is a punctuation character
-{
-	Serial.println("The character is a punctuation");
+if (isPunct(myChar)) {  // tests if myChar is a punctuation character
+  Serial.println("The character is a punctuation");
 }
-else
-{
-	Serial.println("The character is not a punctuation");
+else {
+  Serial.println("The character is not a punctuation");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isSpace.adoc
+++ b/Language/Functions/Characters/isSpace.adoc
@@ -50,15 +50,12 @@ isSpace(thisChar)
 
 [source,arduino]
 ----
-if (isSpace(myChar))      // tests if myChar is the space character
-{
-	Serial.println("The character is a space");
+if (isSpace(myChar)) {  // tests if myChar is the space character
+  Serial.println("The character is a space");
 }
-else
-{
-	Serial.println("The character is not a space");
+else {
+  Serial.println("The character is not a space");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isUpperCase.adoc
+++ b/Language/Functions/Characters/isUpperCase.adoc
@@ -46,15 +46,12 @@ isUpperCase(thisChar)
 
 [source,arduino]
 ----
-if (isUpperCase(myChar))      // tests if myChar is an upper case letter
-{
-	Serial.println("The character is upper case");
+if (isUpperCase(myChar)) {  // tests if myChar is an upper case letter
+  Serial.println("The character is upper case");
 }
-else
-{
-	Serial.println("The character is not upper case");
+else {
+  Serial.println("The character is not upper case");
 }
-
 ----
 
 --

--- a/Language/Functions/Characters/isWhitespace.adoc
+++ b/Language/Functions/Characters/isWhitespace.adoc
@@ -50,15 +50,12 @@ isWhitespace(thisChar)
 
 [source,arduino]
 ----
-if (isWhitespace(myChar))      // tests if myChar is a white space
-{
-	Serial.println("The character is a white space");
+if (isWhitespace(myChar)) { // tests if myChar is a white space
+  Serial.println("The character is a white space");
 }
-else
-{
-	Serial.println("The character is not a white space");
+else {
+  Serial.println("The character is not a white space");
 }
-
 ----
 
 --

--- a/Language/Functions/Communication/Serial/available.adoc
+++ b/Language/Functions/Communication/Serial/available.adoc
@@ -41,23 +41,22 @@ The following code returns a character received through the serial port.
 
 [source,arduino]
 ----
-int incomingByte = 0;	// for incoming serial data
+int incomingByte = 0; // for incoming serial data
 
 void setup() {
-	Serial.begin(9600);	// opens serial port, sets data rate to 9600 bps
+  Serial.begin(9600); // opens serial port, sets data rate to 9600 bps
 }
 
 void loop() {
+  // reply only when you receive data:
+  if (Serial.available() > 0) {
+    // read the incoming byte:
+    incomingByte = Serial.read();
 
-	// reply only when you receive data:
-	if (Serial.available() > 0) {
-		// read the incoming byte:
-		incomingByte = Serial.read();
-
-		// say what you got:
-		Serial.print("I received: ");
-		Serial.println(incomingByte, DEC);
-	}
+    // say what you got:
+    Serial.print("I received: ");
+    Serial.println(incomingByte, DEC);
+  }
 }
 ----
 [%hardbreaks]
@@ -70,7 +69,6 @@ This code sends data received in one serial port of the Arduino Mega to another.
 void setup() {
   Serial.begin(9600);
   Serial1.begin(9600);
-
 }
 
 void loop() {
@@ -78,7 +76,6 @@ void loop() {
   if (Serial.available()) {
     int inByte = Serial.read();
     Serial1.print(inByte, DEC);
-
   }
   // read from port 1, send to port 0:
   if (Serial1.available()) {

--- a/Language/Functions/Communication/Serial/begin.adoc
+++ b/Language/Functions/Communication/Serial/begin.adoc
@@ -96,7 +96,7 @@ void loop() {}
 // (Serial, Serial1, Serial2, Serial3),
 // with different baud rates:
 
-void setup(){
+void setup() {
   Serial.begin(9600);
   Serial1.begin(38400);
   Serial2.begin(19200);

--- a/Language/Functions/Communication/Serial/ifSerial.adoc
+++ b/Language/Functions/Communication/Serial/ifSerial.adoc
@@ -52,7 +52,7 @@ Nothing
 [source,arduino]
 ----
 void setup() {
- //Initialize serial and wait for port to open:
+  //Initialize serial and wait for port to open:
   Serial.begin(9600);
   while (!Serial) {
     ; // wait for serial port to connect. Needed for native USB
@@ -60,7 +60,7 @@ void setup() {
 }
 
 void loop() {
- //proceed normally
+  //proceed normally
 }
 ----
 

--- a/Language/Functions/Communication/Serial/print.adoc
+++ b/Language/Functions/Communication/Serial/print.adoc
@@ -73,16 +73,16 @@ To send data without conversion to its representation as characters, use link:..
 [source,arduino]
 ----
 /*
-Uses a for loop to print numbers in various formats.
+  Uses a for loop to print numbers in various formats.
 */
 void setup() {
-  Serial.begin(9600);      // open the serial port at 9600 bps:
+  Serial.begin(9600); // open the serial port at 9600 bps:
 }
 
 void loop() {
   // print labels
   Serial.print("NO FORMAT");  // prints a label
-  Serial.print("\t");      // prints a tab
+  Serial.print("\t");         // prints a tab
 
   Serial.print("DEC");
   Serial.print("\t");

--- a/Language/Functions/Communication/Serial/read.adoc
+++ b/Language/Functions/Communication/Serial/read.adoc
@@ -50,23 +50,22 @@ The first byte of incoming serial data available (or -1 if no data is available)
 
 [source,arduino]
 ----
-int incomingByte = 0;   // for incoming serial data
+int incomingByte = 0; // for incoming serial data
 
 void setup() {
-        Serial.begin(9600);     // opens serial port, sets data rate to 9600 bps
+  Serial.begin(9600); // opens serial port, sets data rate to 9600 bps
 }
 
 void loop() {
+  // send data only when you receive data:
+  if (Serial.available() > 0) {
+    // read the incoming byte:
+    incomingByte = Serial.read();
 
-        // send data only when you receive data:
-        if (Serial.available() > 0) {
-                // read the incoming byte:
-                incomingByte = Serial.read();
-
-                // say what you got:
-                Serial.print("I received: ");
-                Serial.println(incomingByte, DEC);
-        }
+    // say what you got:
+    Serial.print("I received: ");
+    Serial.println(incomingByte, DEC);
+  }
 }
 ----
 

--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -23,23 +23,23 @@ Called when data is available. Use `Serial.read()` to capture this data.
 
 [source,arduino]
 ----
-void serialEvent(){
-//statements
+void serialEvent() {
+  //statements
 }
 ----
 For boards with additional serial ports (see the list of available serial ports for each board on the link:../../serial[Serial main page]):
 [source,arduino]
 ----
-void serialEvent1(){
-//statements
+void serialEvent1() {
+  //statements
 }
 
-void serialEvent2(){
-//statements
+void serialEvent2() {
+  //statements
 }
 
-void serialEvent3(){
-//statements
+void serialEvent3() {
+  //statements
 }
 ----
 

--- a/Language/Functions/Communication/Serial/write.adoc
+++ b/Language/Functions/Communication/Serial/write.adoc
@@ -56,14 +56,14 @@ Writes binary data to the serial port. This data is sent as a byte or series of 
 
 [source,arduino]
 ----
-void setup(){
+void setup() {
   Serial.begin(9600);
 }
 
-void loop(){
+void loop() {
   Serial.write(45); // send a byte with the value 45
 
-   int bytesSent = Serial.write(“hello”); //send the string “hello” and return the length of the string.
+  int bytesSent = Serial.write(“hello”);  //send the string “hello” and return the length of the string.
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Digital IO/digitalRead.adoc
+++ b/Language/Functions/Digital IO/digitalRead.adoc
@@ -51,20 +51,18 @@ Sets pin 13 to the same value as pin 7, declared as an input.
 
 [source,arduino]
 ----
-int ledPin = 13;   // LED connected to digital pin 13
-int inPin = 7;     // pushbutton connected to digital pin 7
-int val = 0;       // variable to store the read value
+int ledPin = 13;  // LED connected to digital pin 13
+int inPin = 7;    // pushbutton connected to digital pin 7
+int val = 0;      // variable to store the read value
 
-void setup()
-{
-  pinMode(ledPin, OUTPUT);      // sets the digital pin 13 as output
-  pinMode(inPin, INPUT);        // sets the digital pin 7 as input
+void setup() {
+  pinMode(ledPin, OUTPUT);  // sets the digital pin 13 as output
+  pinMode(inPin, INPUT);    // sets the digital pin 7 as input
 }
 
-void loop()
-{
-  val = digitalRead(inPin);     // read the input pin
-  digitalWrite(ledPin, val);    // sets the LED to the button's value
+void loop() {
+  val = digitalRead(inPin);   // read the input pin
+  digitalWrite(ledPin, val);  // sets the LED to the button's value
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Digital IO/digitalWrite.adoc
+++ b/Language/Functions/Digital IO/digitalWrite.adoc
@@ -60,17 +60,15 @@ The code makes the digital pin 13 an `OUTPUT` and toggles it by alternating betw
 
 [source,arduino]
 ----
-void setup()
-{
-  pinMode(13, OUTPUT);          // sets the digital pin 13 as output
+void setup() {
+  pinMode(13, OUTPUT);    // sets the digital pin 13 as output
 }
 
-void loop()
-{
-  digitalWrite(13, HIGH);       // sets the digital pin 13 on
-  delay(1000);                  // waits for a second
-  digitalWrite(13, LOW);        // sets the digital pin 13 off
-  delay(1000);                  // waits for a second
+void loop() {
+  digitalWrite(13, HIGH); // sets the digital pin 13 on
+  delay(1000);            // waits for a second
+  digitalWrite(13, LOW);  // sets the digital pin 13 off
+  delay(1000);            // waits for a second
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Digital IO/pinMode.adoc
+++ b/Language/Functions/Digital IO/pinMode.adoc
@@ -55,17 +55,15 @@ The code makes the digital pin 13 `OUTPUT` and Toggles it `HIGH` and `LOW`
 
 [source,arduino]
 ----
-void setup()
-{
-  pinMode(13, OUTPUT);          // sets the digital pin 13 as output
+void setup() {
+  pinMode(13, OUTPUT);    // sets the digital pin 13 as output
 }
 
-void loop()
-{
-  digitalWrite(13, HIGH);       // sets the digital pin 13 on
-  delay(1000);                  // waits for a second
-  digitalWrite(13, LOW);        // sets the digital pin 13 off
-  delay(1000);                  // waits for a second
+void loop() {
+  digitalWrite(13, HIGH); // sets the digital pin 13 on
+  delay(1000);            // waits for a second
+  digitalWrite(13, LOW);  // sets the digital pin 13 off
+  delay(1000);            // waits for a second
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Interrupts/interrupts.adoc
+++ b/Language/Functions/Interrupts/interrupts.adoc
@@ -53,8 +53,7 @@ The code enables Interrupts.
 ----
 void setup() {}
 
-void loop()
-{
+void loop() {
   noInterrupts();
   // critical, time-sensitive code here
   interrupts();

--- a/Language/Functions/Interrupts/noInterrupts.adoc
+++ b/Language/Functions/Interrupts/noInterrupts.adoc
@@ -53,8 +53,7 @@ The code shows how to enable interrupts.
 ----
 void setup() {}
 
-void loop()
-{
+void loop() {
   noInterrupts();
   // critical, time-sensitive code here
   interrupts();

--- a/Language/Functions/Math/abs.adoc
+++ b/Language/Functions/Math/abs.adoc
@@ -51,10 +51,11 @@ Calculates the absolute value of a number.
 Because of the way the abs() function is implemented, avoid using other functions inside the brackets, it may lead to incorrect results.
 [source,arduino]
 ----
-abs(a++);   // avoid this - yields incorrect results
+abs(a++); // avoid this - yields incorrect results
 
-abs(a);         // use this instead -
-a++;        // keep other math outside the function
+// use this instead:
+abs(a);
+a++;  // keep other math outside the function
 ----
 [%hardbreaks]
 

--- a/Language/Functions/Math/constrain.adoc
+++ b/Language/Functions/Math/constrain.adoc
@@ -57,7 +57,7 @@ The code limits the sensor values to between 10 to 150.
 
 [source,arduino]
 ----
-sensVal = constrain(sensVal, 10, 150);    // limits range of sensor values to between 10 and 150
+sensVal = constrain(sensVal, 10, 150);  // limits range of sensor values to between 10 and 150
 ----
 
 [float]

--- a/Language/Functions/Math/map.adoc
+++ b/Language/Functions/Math/map.adoc
@@ -76,8 +76,7 @@ The mapped value.
 /* Map an analog value to 8 bits (0 to 255) */
 void setup() {}
 
-void loop()
-{
+void loop() {
   int val = analogRead(0);
   val = map(val, 0, 1023, 0, 255);
   analogWrite(9, val);
@@ -92,8 +91,7 @@ For the mathematically inclined, here's the whole function
 
 [source,arduino]
 ----
-long map(long x, long in_min, long in_max, long out_min, long out_max)
-{
+long map(long x, long in_min, long in_max, long out_min, long out_max) {
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
 ----

--- a/Language/Functions/Math/max.adoc
+++ b/Language/Functions/Math/max.adoc
@@ -53,7 +53,7 @@ The code ensures that sensVal is at least 20.
 [source,arduino]
 ----
 sensVal = max(sensVal, 20); // assigns sensVal to the larger of sensVal or 20
-                           // (effectively ensuring that it is at least 20)
+                            // (effectively ensuring that it is at least 20)
 ----
 [%hardbreaks]
 
@@ -64,10 +64,11 @@ Perhaps counter-intuitively, `max()` is often used to constrain the lower end of
 Because of the way the `max()` function is implemented, avoid using other functions inside the brackets, it may lead to incorrect results
 [source,arduino]
 ----
-max(a--, 0);   // avoid this - yields incorrect results
+max(a--, 0);  // avoid this - yields incorrect results
 
-max(a, 0);           // use this instead -
-a--;     // keep other math outside the function
+// use this instead:
+max(a, 0);
+a--;  // keep other math outside the function
 ----
 
 --

--- a/Language/Functions/Math/min.adoc
+++ b/Language/Functions/Math/min.adoc
@@ -53,8 +53,8 @@ The code ensures that it never gets above 100.
 
 [source,arduino]
 ----
-sensVal = min(sensVal, 100); // assigns sensVal to the smaller of sensVal or 100
-                             // ensuring that it never gets above 100.
+sensVal = min(sensVal, 100);  // assigns sensVal to the smaller of sensVal or 100
+                              // ensuring that it never gets above 100.
 ----
 [%hardbreaks]
 
@@ -65,10 +65,10 @@ Perhaps counter-intuitively, `max()` is often used to constrain the lower end of
 Because of the way the `min()` function is implemented, avoid using other functions inside the brackets, it may lead to incorrect results
 [source,arduino]
 ----
-min(a++, 100);   // avoid this - yields incorrect results
+min(a++, 100);  // avoid this - yields incorrect results
 
 min(a, 100);
-a++;    // use this instead - keep other math outside the function
+a++;  // use this instead - keep other math outside the function
 ----
 
 --

--- a/Language/Functions/Random Numbers/random.adoc
+++ b/Language/Functions/Random Numbers/random.adoc
@@ -56,7 +56,7 @@ The code generates random numbers and displays them.
 ----
 long randNumber;
 
-void setup(){
+void setup() {
   Serial.begin(9600);
 
   // if analog input pin 0 is unconnected, random analog

--- a/Language/Functions/Random Numbers/randomSeed.adoc
+++ b/Language/Functions/Random Numbers/randomSeed.adoc
@@ -55,15 +55,14 @@ The code generates a pseudo-random number and sends the generated number to the 
 ----
 long randNumber;
 
-void setup(){
+void setup() {
   Serial.begin(9600);
   randomSeed(analogRead(0));
 }
 
-void loop(){
+void loop() {
   randNumber = random(300);
   Serial.println(randNumber);
-
   delay(50);
 }
 ----

--- a/Language/Functions/Time/delay.adoc
+++ b/Language/Functions/Time/delay.adoc
@@ -51,19 +51,17 @@ The code pauses the program for one second before toggling the output pin.
 
 [source,arduino]
 ----
-int ledPin = 13;                 // LED connected to digital pin 13
+int ledPin = 13;              // LED connected to digital pin 13
 
-void setup()
-{
-  pinMode(ledPin, OUTPUT);      // sets the digital pin as output
+void setup() {
+  pinMode(ledPin, OUTPUT);    // sets the digital pin as output
 }
 
-void loop()
-{
-  digitalWrite(ledPin, HIGH);   // sets the LED on
-  delay(1000);                  // waits for a second
-  digitalWrite(ledPin, LOW);    // sets the LED off
-  delay(1000);                  // waits for a second
+void loop() {
+  digitalWrite(ledPin, HIGH); // sets the LED on
+  delay(1000);                // waits for a second
+  digitalWrite(ledPin, LOW);  // sets the LED off
+  delay(1000);                // waits for a second
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Time/delayMicroseconds.adoc
+++ b/Language/Functions/Time/delayMicroseconds.adoc
@@ -53,19 +53,17 @@ The code configures pin number 8 to work as an output pin. It sends a train of p
 
 [source,arduino]
 ----
-int outPin = 8;                 // digital pin 8
+int outPin = 8;               // digital pin 8
 
-void setup()
-{
-  pinMode(outPin, OUTPUT);      // sets the digital pin as output
+void setup() {
+  pinMode(outPin, OUTPUT);    // sets the digital pin as output
 }
 
-void loop()
-{
-  digitalWrite(outPin, HIGH);   // sets the pin on
-  delayMicroseconds(50);        // pauses for 50 microseconds
-  digitalWrite(outPin, LOW);    // sets the pin off
-  delayMicroseconds(50);        // pauses for 50 microseconds
+void loop() {
+  digitalWrite(outPin, HIGH); // sets the pin on
+  delayMicroseconds(50);      // pauses for 50 microseconds
+  digitalWrite(outPin, LOW);  // sets the pin off
+  delayMicroseconds(50);      // pauses for 50 microseconds
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Time/micros.adoc
+++ b/Language/Functions/Time/micros.adoc
@@ -53,15 +53,15 @@ The code returns the number of microseconds since the Arduino board began.
 ----
 unsigned long time;
 
-void setup(){
+void setup() {
   Serial.begin(9600);
 }
-void loop(){
+void loop() {
   Serial.print("Time: ");
   time = micros();
 
-  Serial.println(time);  //prints time since program started
-  delay(1000);           // wait a second so as not to send massive amounts of data
+  Serial.println(time); //prints time since program started
+  delay(1000);          // wait a second so as not to send massive amounts of data
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/Time/millis.adoc
+++ b/Language/Functions/Time/millis.adoc
@@ -53,15 +53,15 @@ The code reads the milllisecond since the Arduino board began.
 ----
 unsigned long time;
 
-void setup(){
+void setup() {
   Serial.begin(9600);
 }
-void loop(){
+void loop() {
   Serial.print("Time: ");
   time = millis();
 
-  Serial.println(time);    //prints time since program started
-  delay(1000);             // wait a second so as not to send massive amounts of data
+  Serial.println(time); //prints time since program started
+  delay(1000);          // wait a second so as not to send massive amounts of data
 }
 ----
 [%hardbreaks]

--- a/Language/Functions/USB/Keyboard/keyboardBegin.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardBegin.adoc
@@ -60,7 +60,7 @@ void setup() {
 
 void loop() {
   //if the button is pressed
-  if(digitalRead(2)==LOW){
+  if (digitalRead(2) == LOW) {
     //Send the message
     Keyboard.print("Hello!");
   }

--- a/Language/Functions/USB/Keyboard/keyboardEnd.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardEnd.adoc
@@ -60,7 +60,7 @@ void setup() {
 }
 
 void loop() {
- //do nothing
+  //do nothing
 }
 ----
 

--- a/Language/Functions/USB/Keyboard/keyboardPrint.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPrint.adoc
@@ -62,7 +62,7 @@ void setup() {
 
 void loop() {
   //if the button is pressed
-  if(digitalRead(2)==LOW){
+  if (digitalRead(2) == LOW) {
     //Send the message
     Keyboard.print("Hello!");
   }

--- a/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
@@ -63,7 +63,7 @@ void setup() {
 
 void loop() {
   //if the button is pressed
-  if(digitalRead(2)==LOW){
+  if (digitalRead(2) == LOW) {
     //Send the message
     Keyboard.println("Hello!");
   }

--- a/Language/Functions/USB/Keyboard/keyboardWrite.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardWrite.adoc
@@ -71,7 +71,7 @@ void setup() {
 
 void loop() {
   //if the button is pressed
-  if(digitalRead(2)==LOW){
+  if (digitalRead(2) == LOW) {
     //Send an ASCII 'A',
     Keyboard.write(65);
   }

--- a/Language/Functions/USB/Mouse/mouseBegin.adoc
+++ b/Language/Functions/USB/Mouse/mouseBegin.adoc
@@ -51,17 +51,15 @@ Nothing
 ----
 #include <Mouse.h>
 
-void setup(){
- pinMode(2, INPUT);
+void setup() {
+  pinMode(2, INPUT);
 }
 
-void loop(){
-
+void loop() {
   //initiate the Mouse library when button is pressed
-  if(digitalRead(2) == HIGH){
-     Mouse.begin();
-   }
-
+  if (digitalRead(2) == HIGH) {
+    Mouse.begin();
+  }
 }
 ----
 

--- a/Language/Functions/USB/Mouse/mouseClick.adoc
+++ b/Language/Functions/USB/Mouse/mouseClick.adoc
@@ -22,8 +22,8 @@ Sends a momentary click to the computer at the location of the cursor. This is t
 
 [float]
 === Syntax
-`Mouse.click();` +
-`Mouse.click(button);`
+`Mouse.click()` +
+`Mouse.click(button)`
 
 
 [float]
@@ -57,15 +57,15 @@ Nothing
 ----
 #include <Mouse.h>
 
-void setup(){
-  pinMode(2,INPUT);
+void setup() {
+  pinMode(2, INPUT);
   //initiate the Mouse library
   Mouse.begin();
 }
 
-void loop(){
+void loop() {
   //if the button is pressed, send a left mouse click
-  if(digitalRead(2) == HIGH){
+  if (digitalRead(2) == HIGH) {
     Mouse.click();
   }
 }

--- a/Language/Functions/USB/Mouse/mouseEnd.adoc
+++ b/Language/Functions/USB/Mouse/mouseEnd.adoc
@@ -50,21 +50,20 @@ Nothing
 ----
 #include <Mouse.h>
 
-void setup(){
-  pinMode(2,INPUT);
+void setup() {
+  pinMode(2, INPUT);
   //initiate the Mouse library
   Mouse.begin();
 }
 
-void loop(){
+void loop() {
   //if the button is pressed, send a left mouse click
   //then end the Mouse emulation
-  if(digitalRead(2) == HIGH){
+  if (digitalRead(2) == HIGH) {
     Mouse.click();
     Mouse.end();
   }
 }
-
 ----
 
 --

--- a/Language/Functions/USB/Mouse/mouseIsPressed.adoc
+++ b/Language/Functions/USB/Mouse/mouseIsPressed.adoc
@@ -58,29 +58,29 @@ When there is no value passed, it checks the status of the left mouse button.
 ----
 #include <Mouse.h>
 
-void setup(){
+void setup() {
   //The switch that will initiate the Mouse press
-  pinMode(2,INPUT);
+  pinMode(2, INPUT);
   //The switch that will terminate the Mouse press
-  pinMode(3,INPUT);
+  pinMode(3, INPUT);
   //Start serial communication with the computer
   Serial.begin(9600);
   //initiate the Mouse library
   Mouse.begin();
 }
 
-void loop(){
+void loop() {
   //a variable for checking the button's state
-  int mouseState=0;
+  int mouseState = 0;
   //if the switch attached to pin 2 is closed, press and hold the left mouse button and save the state ina  variable
-  if(digitalRead(2) == HIGH){
+  if (digitalRead(2) == HIGH) {
     Mouse.press();
-    mouseState=Mouse.isPressed();
+    mouseState = Mouse.isPressed();
   }
   //if the switch attached to pin 3 is closed, release the left mouse button and save the state in a variable
-  if(digitalRead(3) == HIGH){
+  if (digitalRead(3) == HIGH) {
     Mouse.release();
-    mouseState=Mouse.isPressed();
+    mouseState = Mouse.isPressed();
   }
   //print out the current mouse button state
   Serial.println(mouseState);

--- a/Language/Functions/USB/Mouse/mouseMove.adoc
+++ b/Language/Functions/USB/Mouse/mouseMove.adoc
@@ -57,31 +57,27 @@ const int xAxis = A1;         //analog sensor for X axis
 const int yAxis = A2;         // analog sensor for Y axis
 
 int range = 12;               // output range of X or Y movement
-int responseDelay = 2;       // response delay of the mouse, in ms
-int threshold = range/4;      // resting threshold
-int center = range/2;         // resting position value
-int minima[] = {
-  1023, 1023};                // actual analogRead minima for {x, y}
-int maxima[] = {
-  0,0};                       // actual analogRead maxima for {x, y}
-int axis[] = {
-  xAxis, yAxis};              // pin numbers for {x, y}
+int responseDelay = 2;        // response delay of the mouse, in ms
+int threshold = range / 4;    // resting threshold
+int center = range / 2;       // resting position value
+int minima[] = {1023, 1023};  // actual analogRead minima for {x, y}
+int maxima[] = {0, 0};        // actual analogRead maxima for {x, y}
+int axis[] = {xAxis, yAxis};  // pin numbers for {x, y}
 int mouseReading[2];          // final mouse readings for {x, y}
 
 
 void setup() {
- Mouse.begin();
+  Mouse.begin();
 }
 
 void loop() {
-
-// read and scale the two axes:
+  // read and scale the two axes:
   int xReading = readAxis(0);
   int yReading = readAxis(1);
 
-// move the mouse:
-    Mouse.move(xReading, yReading, 0);
-    delay(responseDelay);
+  // move the mouse:
+  Mouse.move(xReading, yReading, 0);
+  delay(responseDelay);
 }
 
 /*
@@ -90,13 +86,13 @@ void loop() {
 */
 
 int readAxis(int axisNumber) {
-  int distance = 0;    // distance from center of the output range
+  int distance = 0; // distance from center of the output range
 
   // read the analog input:
   int reading = analogRead(axis[axisNumber]);
 
-// of the current reading exceeds the max or min for this axis,
-// reset the max or min:
+  // of the current reading exceeds the max or min for this axis,
+  // reset the max or min:
   if (reading < minima[axisNumber]) {
     minima[axisNumber] = reading;
   }
@@ -107,8 +103,8 @@ int readAxis(int axisNumber) {
   // map the reading from the analog input range to the output range:
   reading = map(reading, minima[axisNumber], maxima[axisNumber], 0, range);
 
- // if the output reading is outside from the
- // rest position threshold,  use it:
+  // if the output reading is outside from the
+  // rest position threshold,  use it:
   if (abs(reading - center) > threshold) {
     distance = (reading - center);
   }

--- a/Language/Functions/USB/Mouse/mousePress.adoc
+++ b/Language/Functions/USB/Mouse/mousePress.adoc
@@ -24,7 +24,7 @@ Before using `Mouse.press()`, you need to start communication with link:../mouse
 
 [float]
 === Syntax
-`Mouse.press();` +
+`Mouse.press()` +
 `Mouse.press(button)`
 
 
@@ -61,22 +61,22 @@ Nothing
 ----
 #include <Mouse.h>
 
-void setup(){
+void setup() {
   //The switch that will initiate the Mouse press
-  pinMode(2,INPUT);
+  pinMode(2, INPUT);
   //The switch that will terminate the Mouse press
-  pinMode(3,INPUT);
+  pinMode(3, INPUT);
   //initiate the Mouse library
   Mouse.begin();
 }
 
-void loop(){
+void loop() {
   //if the switch attached to pin 2 is closed, press and hold the left mouse button
-  if(digitalRead(2) == HIGH){
+  if (digitalRead(2) == HIGH) {
     Mouse.press();
   }
   //if the switch attached to pin 3 is closed, release the left mouse button
-  if(digitalRead(3) == HIGH){
+  if (digitalRead(3) == HIGH) {
     Mouse.release();
   }
 }

--- a/Language/Functions/USB/Mouse/mouseRelease.adoc
+++ b/Language/Functions/USB/Mouse/mouseRelease.adoc
@@ -56,22 +56,22 @@ Nothing
 ----
 #include <Mouse.h>
 
-void setup(){
+void setup() {
   //The switch that will initiate the Mouse press
-  pinMode(2,INPUT);
+  pinMode(2, INPUT);
   //The switch that will terminate the Mouse press
-  pinMode(3,INPUT);
+  pinMode(3, INPUT);
   //initiate the Mouse library
   Mouse.begin();
 }
 
-void loop(){
+void loop() {
   //if the switch attached to pin 2 is closed, press and hold the left mouse button
-  if(digitalRead(2) == HIGH){
+  if (digitalRead(2) == HIGH) {
     Mouse.press();
   }
   //if the switch attached to pin 3 is closed, release the left mouse button
-  if(digitalRead(3) == HIGH){
+  if (digitalRead(3) == HIGH) {
     Mouse.release();
   }
 }

--- a/Language/Functions/Zero, Due, MKR Family/analogWriteResolution.adoc
+++ b/Language/Functions/Zero, Due, MKR Family/analogWriteResolution.adoc
@@ -75,7 +75,7 @@ Explain Code
 
 [source,arduino]
 ----
-void setup(){
+void setup() {
   // open a serial connection
   Serial.begin(9600);
   // make our digital pin an output
@@ -84,7 +84,7 @@ void setup(){
   pinMode(13, OUTPUT);
 }
 
-void loop(){
+void loop() {
   // read the input on A0 and map it to a PWM pin
   // with an attached LED
   int sensorVal = analogRead(A0);
@@ -93,9 +93,9 @@ void loop(){
 
   // the default PWM resolution
   analogWriteResolution(8);
-  analogWrite(11, map(sensorVal, 0, 1023, 0 ,255));
+  analogWrite(11, map(sensorVal, 0, 1023, 0, 255));
   Serial.print(" , 8-bit PWM value : ");
-  Serial.print(map(sensorVal, 0, 1023, 0 ,255));
+  Serial.print(map(sensorVal, 0, 1023, 0, 255));
 
   // change the PWM resolution to 12 bits
   // the full 12 bit resolution is only supported

--- a/Language/Structure/Arithmetic Operators/addition.adoc
+++ b/Language/Structure/Arithmetic Operators/addition.adoc
@@ -50,8 +50,10 @@ sum = operand1 + operand2;
 
 [source,arduino]
 ----
-int a = 5, b = 10, c = 0;
-c = a + b; // the variable 'c' gets a value of 15 after this statement is executed
+int a = 5;
+int b = 10;
+int c = 0;
+c = a + b;  // the variable 'c' gets a value of 15 after this statement is executed
 ----
 [%hardbreaks]
 
@@ -65,9 +67,10 @@ c = a + b; // the variable 'c' gets a value of 15 after this statement is execut
 
 [source,arduino]
 ----
-float a = 5.5, b = 6.6;
+float a = 5.5;
+float b = 6.6;
 int c = 0;
-c = a + b; // the variable 'c' stores a value of 12 only as opposed to the expected sum of 12.1
+c = a + b;  // the variable 'c' stores a value of 12 only as opposed to the expected sum of 12.1
 ----
 [%hardbreaks]
 --

--- a/Language/Structure/Arithmetic Operators/division.adoc
+++ b/Language/Structure/Arithmetic Operators/division.adoc
@@ -51,8 +51,10 @@ result = numerator / denominator;
 
 [source,arduino]
 ----
-int a = 50, b = 10, c = 0;
-c = a / b; // the variable 'c' gets a value of 5 after this statement is executed
+int a = 50;
+int b = 10;
+int c = 0;
+c = a / b;  // the variable 'c' gets a value of 5 after this statement is executed
 ----
 [%hardbreaks]
 
@@ -64,9 +66,10 @@ c = a / b; // the variable 'c' gets a value of 5 after this statement is execute
 
 [source,arduino]
 ----
-float a = 55.5, b = 6.6;
+float a = 55.5;
+float b = 6.6;
 int c = 0;
-c = a / b; // the variable 'c' stores a value of 8 only as opposed to the expected result of 8.409
+c = a / b;  // the variable 'c' stores a value of 8 only as opposed to the expected result of 8.409
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Arithmetic Operators/multiplication.adoc
+++ b/Language/Structure/Arithmetic Operators/multiplication.adoc
@@ -51,8 +51,10 @@ product = operand1 * operand2;
 
 [source,arduino]
 ----
-int a = 5, b = 10, c = 0;
-c = a * b; // the variable 'c' gets a value of 50 after this statement is executed
+int a = 5;
+int b = 10;
+int c = 0;
+c = a * b;  // the variable 'c' gets a value of 50 after this statement is executed
 ----
 [%hardbreaks]
 
@@ -66,9 +68,10 @@ c = a * b; // the variable 'c' gets a value of 50 after this statement is execut
 
 [source,arduino]
 ----
-float a = 5.5, b = 6.6;
+float a = 5.5;
+float b = 6.6;
 int c = 0;
-c = a * b; // the variable 'c' stores a value of 36 only as opposed to the expected product of 36.3
+c = a * b;  // the variable 'c' stores a value of 36 only as opposed to the expected product of 36.3
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Arithmetic Operators/remainder.adoc
+++ b/Language/Structure/Arithmetic Operators/remainder.adoc
@@ -51,12 +51,12 @@ remainder = dividend % divisor;
 [source,arduino]
 ----
 int x = 0;
-x = 7 % 5;    // x now contains 2
-x = 9 % 5;    // x now contains 4
-x = 5 % 5;    // x now contains 0
-x = 4 % 5;    // x now contains 4
-x = -4 % 5;   // x now contains -4
-x = 4 % -5;   // x now contains 4
+x = 7 % 5;  // x now contains 2
+x = 9 % 5;  // x now contains 4
+x = 5 % 5;  // x now contains 0
+x = 4 % 5;  // x now contains 4
+x = -4 % 5; // x now contains -4
+x = 4 % -5; // x now contains 4
 ----
 
 [source,arduino]
@@ -68,10 +68,9 @@ int i = 0;
 
 void setup() {}
 
-void loop()
-{
+void loop() {
   values[i] = analogRead(0);
-  i = (i + 1) % 10;   // remainder operator rolls over variable
+  i = (i + 1) % 10; // remainder operator rolls over variable
 }
 ----
 [%hardbreaks]

--- a/Language/Structure/Arithmetic Operators/subtraction.adoc
+++ b/Language/Structure/Arithmetic Operators/subtraction.adoc
@@ -51,8 +51,10 @@ difference = operand1 - operand2;
 
 [source,arduino]
 ----
-int a = 5, b = 10, c = 0;
-c = a - b; // the variable 'c' gets a value of -5 after this statement is executed
+int a = 5;
+int b = 10;
+int c = 0;
+c = a - b;  // the variable 'c' gets a value of -5 after this statement is executed
 ----
 [%hardbreaks]
 
@@ -66,9 +68,10 @@ c = a - b; // the variable 'c' gets a value of -5 after this statement is execut
 
 [source,arduino]
 ----
-float a = 5.5, b = 6.6;
+float a = 5.5;
+float b = 6.6;
 int c = 0;
-c = a - b; // the variable 'c' stores a value of -1 only as opposed to the expected difference of -1.1
+c = a - b;  // the variable 'c' stores a value of -1 only as opposed to the expected difference of -1.1
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Bitwise Operators/bitshiftLeft.adoc
+++ b/Language/Structure/Bitwise Operators/bitshiftLeft.adoc
@@ -48,8 +48,8 @@ variable << number_of_bits;
 
 [source,arduino]
 ----
-int a = 5;        // binary: 0000000000000101
-int b = a << 3;   // binary: 0000000000101000, or 40 in decimal
+int a = 5;      // binary: 0000000000000101
+int b = a << 3; // binary: 0000000000101000, or 40 in decimal
 ----
 [%hardbreaks]
 
@@ -59,7 +59,7 @@ When you shift a value x by y bits (x << y), the leftmost y bits in x are lost, 
 
 [source,arduino]
 ----
-int x = 5;        // binary: 0000000000000101
+int x = 5;  // binary: 0000000000000101
 int y = 14;
 int result = x << y;  // binary: 0100000000000000 - the first 1 in 101 was discarded
 ----
@@ -90,10 +90,10 @@ void printOut1(int c) {
   for (int bits = 7; bits > -1; bits--) {
     // Compare bits 7-0 in byte
     if (c & (1 << bits)) {
-      Serial.print ("1");
+      Serial.print("1");
     }
     else {
-      Serial.print ("0");
+      Serial.print("0");
     }
   }
 }

--- a/Language/Structure/Bitwise Operators/bitshiftRight.adoc
+++ b/Language/Structure/Bitwise Operators/bitshiftRight.adoc
@@ -48,8 +48,8 @@ variable >> number_of_bits;
 
 [source,arduino]
 ----
-int a = 40;       // binary: 0000000000101000
-int b = a >> 3;   // binary: 0000000000000101, or 5 in decimal
+int a = 40;     // binary: 0000000000101000
+int b = a >> 3; // binary: 0000000000000101, or 5 in decimal
 ----
 [%hardbreaks]
 
@@ -59,7 +59,7 @@ When you shift x right by y bits (x >> y), and the highest bit in x is a 1, the 
 
 [source,arduino]
 ----
-int x = -16;     // binary: 1111111111110000
+int x = -16;  // binary: 1111111111110000
 int y = 3;
 int result = x >> y;  // binary: 1111111111111110
 ----
@@ -67,7 +67,7 @@ This behavior, called sign extension, is often not the behavior you want. Instea
 
 [source,arduino]
 ----
-int x = -16;                   // binary: 1111111111110000
+int x = -16;  // binary: 1111111111110000
 int y = 3;
 int result = (unsigned int)x >> y;  // binary: 0001111111111110
 ----
@@ -76,7 +76,7 @@ If you are careful to avoid sign extension, you can use the right-shift operator
 [source,arduino]
 ----
 int x = 1000;
-int y = x >> 3;   // integer division of 1000 by 8, causing y = 125.
+int y = x >> 3; // integer division of 1000 by 8, causing y = 125.
 ----
 
 --

--- a/Language/Structure/Bitwise Operators/bitwiseNot.adoc
+++ b/Language/Structure/Bitwise Operators/bitwiseNot.adoc
@@ -41,8 +41,8 @@ In other words:
 
 [source,arduino]
 ----
-int a = 103;    // binary:  0000000001100111
-int b = ~a;     // binary:  1111111110011000 = -104
+int a = 103;  // binary:  0000000001100111
+int b = ~a;   // binary:  1111111110011000 = -104
 ----
 [%hardbreaks]
 
@@ -50,7 +50,7 @@ int b = ~a;     // binary:  1111111110011000 = -104
 === Notes and Warnings
 You might be surprised to see a negative number like -104 as the result of this operation. This is because the highest bit in an int variable is the so-called sign bit. If the highest bit is 1, the number is interpreted as negative. This encoding of positive and negative numbers is referred to as two's complement. For more information, see the Wikipedia article on http://en.wikipedia.org/wiki/Twos_complement[two's complement^].
 
-As an aside, it is interesting to note that for any integer x, ~x is the same as -x-1.
+As an aside, it is interesting to note that for any integer x, ~x is the same as -x - 1.
 
 At times, the sign bit in a signed integer expression can cause some unwanted surprises.
 [%hardbreaks]

--- a/Language/Structure/Bitwise Operators/bitwiseXor.adoc
+++ b/Language/Structure/Bitwise Operators/bitwiseXor.adoc
@@ -55,14 +55,14 @@ The ^ operator is often used to toggle (i.e. change from 0 to 1, or 1 to 0) some
 ----
 // Note: This code uses registers specific to AVR microcontrollers (Uno, Nano, Leonardo, Mega, etc.)
 // it will not compile for other architectures
-void setup(){
-DDRB = DDRB | B00100000; // set PB5 (pin 13 on Uno/Nano, pin 9 on Leonardo/Micro, pin 11 on Mega) as OUTPUT
-Serial.begin(9600);
+void setup() {
+  DDRB = DDRB | B00100000;  // set PB5 (pin 13 on Uno/Nano, pin 9 on Leonardo/Micro, pin 11 on Mega) as OUTPUT
+  Serial.begin(9600);
 }
 
-void loop(){
-PORTB = PORTB ^ B00100000;  // invert PB5, leave others untouched
-delay(100);
+void loop() {
+  PORTB = PORTB ^ B00100000;  // invert PB5, leave others untouched
+  delay(100);
 }
 ----
 

--- a/Language/Structure/Boolean Operators/logicalAnd.adoc
+++ b/Language/Structure/Boolean Operators/logicalAnd.adoc
@@ -36,8 +36,8 @@ This operator can be used inside the condition of an link:../../control-structur
 
 [source,arduino]
 ----
-if (digitalRead(2) == HIGH  && digitalRead(3) == HIGH) { // if BOTH the switches read HIGH
-    // statements
+if (digitalRead(2) == HIGH && digitalRead(3) == HIGH) { // if BOTH the switches read HIGH
+  // statements
 }
 ----
 [%hardbreaks]

--- a/Language/Structure/Boolean Operators/logicalNot.adoc
+++ b/Language/Structure/Boolean Operators/logicalNot.adoc
@@ -44,7 +44,7 @@ if (!x) { // if x is not true
 It can be used to invert the boolean value.
 [source,arduino]
 ----
-x = !y;   // the inverted value of y is stored in x
+x = !y; // the inverted value of y is stored in x
 ----
 
 

--- a/Language/Structure/Comparison Operators/equalTo.adoc
+++ b/Language/Structure/Comparison Operators/equalTo.adoc
@@ -26,7 +26,7 @@ Compares the variable on the left with the value or variable on the right of the
 === Syntax
 [source,arduino]
 ----
-x == y;   // is true if x is equal to y and it is false if x is not equal to y
+x == y; // is true if x is equal to y and it is false if x is not equal to y
 ----
 
 [float]
@@ -48,9 +48,8 @@ x == y;   // is true if x is equal to y and it is false if x is not equal to y
 
 [source,arduino]
 ----
-if (x==y)      // tests if x is equal to y
-{
-// do something only if the comparison result is true
+if (x == y) { // tests if x is equal to y
+  // do something only if the comparison result is true
 }
 ----
 [%hardbreaks]

--- a/Language/Structure/Comparison Operators/greaterThan.adoc
+++ b/Language/Structure/Comparison Operators/greaterThan.adoc
@@ -26,7 +26,7 @@ Compares the variable on the left with the value or variable on the right of the
 === Syntax
 [source,arduino]
 ----
-x > y;   // is true if x is bigger than y and it is false if x is equal or smaller than y
+x > y;  // is true if x is bigger than y and it is false if x is equal or smaller than y
 ----
 
 [float]
@@ -48,9 +48,8 @@ x > y;   // is true if x is bigger than y and it is false if x is equal or small
 
 [source,arduino]
 ----
-if (x>y)      // tests if x is greater (bigger) than y
-{
-// do something only if the comparison result is true
+if (x > y) {  // tests if x is greater (bigger) than y
+  // do something only if the comparison result is true
 }
 ----
 [%hardbreaks]

--- a/Language/Structure/Comparison Operators/greaterThanOrEqualTo.adoc
+++ b/Language/Structure/Comparison Operators/greaterThanOrEqualTo.adoc
@@ -26,7 +26,7 @@ Compares the variable on the left with the value or variable on the right of the
 === Syntax
 [source,arduino]
 ----
-x >= y;   // is true if x is bigger than or equal to y and it is false if x is smaller than y
+x >= y; // is true if x is bigger than or equal to y and it is false if x is smaller than y
 ----
 
 [float]
@@ -48,9 +48,8 @@ x >= y;   // is true if x is bigger than or equal to y and it is false if x is s
 
 [source,arduino]
 ----
-if (x>=y)      // tests if x is greater (bigger) than or equal to y
-{
-// do something only if the comparison result is true
+if (x >= y) { // tests if x is greater (bigger) than or equal to y
+  // do something only if the comparison result is true
 }
 ----
 [%hardbreaks]

--- a/Language/Structure/Comparison Operators/lessThan.adoc
+++ b/Language/Structure/Comparison Operators/lessThan.adoc
@@ -26,7 +26,7 @@ Compares the variable on the left with the value or variable on the right of the
 === Syntax
 [source,arduino]
 ----
-x < y;   // is true if x is smaller than y and it is false if x is equal or bigger than y
+x < y;  // is true if x is smaller than y and it is false if x is equal or bigger than y
 ----
 
 [float]
@@ -48,9 +48,8 @@ x < y;   // is true if x is smaller than y and it is false if x is equal or bigg
 
 [source,arduino]
 ----
-if (x<y)      // tests if x is less (smaller) than y
-{
-// do something only if the comparison result is true
+if (x < y) {  // tests if x is less (smaller) than y
+  // do something only if the comparison result is true
 }
 ----
 [%hardbreaks]

--- a/Language/Structure/Comparison Operators/lessThanOrEqualTo.adoc
+++ b/Language/Structure/Comparison Operators/lessThanOrEqualTo.adoc
@@ -26,7 +26,7 @@ Compares the variable on the left with the value or variable on the right of the
 === Syntax
 [source,arduino]
 ----
-x <= y;   // is true if x is smaller than or equal to y and it is false if x is greater than y
+x <= y; // is true if x is smaller than or equal to y and it is false if x is greater than y
 ----
 
 [float]
@@ -48,9 +48,8 @@ x <= y;   // is true if x is smaller than or equal to y and it is false if x is 
 
 [source,arduino]
 ----
-if (x<=y)      // tests if x is less (smaller) than or equal to y
-{
-// do something only if the comparison result is true
+if (x <= y) { // tests if x is less (smaller) than or equal to y
+  // do something only if the comparison result is true
 }
 ----
 [%hardbreaks]

--- a/Language/Structure/Comparison Operators/notEqualTo.adoc
+++ b/Language/Structure/Comparison Operators/notEqualTo.adoc
@@ -26,7 +26,7 @@ Compares the variable on the left with the value or variable on the right of the
 === Syntax
 [source,arduino]
 ----
-x != y;   // is false if x is equal to y and it is true if x is not equal to y
+x != y; // is false if x is equal to y and it is true if x is not equal to y
 ----
 
 [float]
@@ -48,9 +48,8 @@ x != y;   // is false if x is equal to y and it is true if x is not equal to y
 
 [source,arduino]
 ----
-if (x!=y)      // tests if x is not equal to y
-{
-// do something only if the comparison result is true
+if (x != y) { // tests if x is not equal to y
+  // do something only if the comparison result is true
 }
 ----
 [%hardbreaks]

--- a/Language/Structure/Compound Operators/compoundAddition.adoc
+++ b/Language/Structure/Compound Operators/compoundAddition.adoc
@@ -26,7 +26,7 @@ This is a convenient shorthand to perform addition on a variable with another co
 === Syntax
 [source,arduino]
 ----
-x += y;   // equivalent to the expression x = x + y;
+x += y; // equivalent to the expression x = x + y;
 ----
 
 [float]
@@ -49,7 +49,7 @@ x += y;   // equivalent to the expression x = x + y;
 [source,arduino]
 ----
 x = 2;
-x += 4;      // x now contains 6
+x += 4; // x now contains 6
 ----
 
 --

--- a/Language/Structure/Compound Operators/compoundBitwiseAnd.adoc
+++ b/Language/Structure/Compound Operators/compoundBitwiseAnd.adoc
@@ -33,7 +33,7 @@ A review of the Bitwise AND `&` operator:
 === Syntax
 [source,arduino]
 ----
-x &= y;   // equivalent to x = x & y;
+x &= y; // equivalent to x = x & y;
 ----
 
 [float]
@@ -95,8 +95,8 @@ So if:
 
 [source,arduino]
 ----
-myByte =  B10101010;
-myByte &= B11111100; // results in B10101000
+myByte = B10101010;
+myByte &= B11111100;  // results in B10101000
 ----
 
 [%hardbreaks]

--- a/Language/Structure/Compound Operators/compoundBitwiseOr.adoc
+++ b/Language/Structure/Compound Operators/compoundBitwiseOr.adoc
@@ -29,7 +29,7 @@ A review of the Bitwise OR `|` operator:
 === Syntax
 [source,arduino]
 ----
-x |= y;   // equivalent to x = x | y;
+x |= y; // equivalent to x = x | y;
 ----
 
 [float]
@@ -90,7 +90,7 @@ Here is the same representation with the variables bits replaced with the symbol
 So if:
 [source,arduino]
 ----
-myByte =  B10101010;
+myByte = B10101010;
 myByte |= B00000011 == B10101011;
 ----
 

--- a/Language/Structure/Compound Operators/compoundBitwiseXor.adoc
+++ b/Language/Structure/Compound Operators/compoundBitwiseXor.adoc
@@ -29,7 +29,7 @@ A review of the Bitwise XOR `^` operator:
 === Syntax
 [source,arduino]
 ----
-x ^= y;   // equivalent to x = x ^ y;
+x ^= y; // equivalent to x = x ^ y;
 ----
 
 [float]
@@ -90,7 +90,7 @@ Here is the same representation with the variables bits replaced with the symbol
 So if:
 [source,arduino]
 ----
-myByte =  B10101010;
+myByte = B10101010;
 myByte ^= B00000011 == B10101001;
 ----
 

--- a/Language/Structure/Compound Operators/compoundDivision.adoc
+++ b/Language/Structure/Compound Operators/compoundDivision.adoc
@@ -26,7 +26,7 @@ This is a convenient shorthand to perform division of a variable with another co
 === Syntax
 [source,arduino]
 ----
-x /= y;   // equivalent to the expression x = x / y;
+x /= y; // equivalent to the expression x = x / y;
 ----
 
 [float]
@@ -49,7 +49,7 @@ x /= y;   // equivalent to the expression x = x / y;
 [source,arduino]
 ----
 x = 2;
-x /= 2;      // x now contains 1
+x /= 2; // x now contains 1
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Compound Operators/compoundMultiplication.adoc
+++ b/Language/Structure/Compound Operators/compoundMultiplication.adoc
@@ -26,7 +26,7 @@ This is a convenient shorthand to perform multiplication of a variable with anot
 === Syntax
 [source,arduino]
 ----
-x *= y;   // equivalent to the expression x = x * y;
+x *= y; // equivalent to the expression x = x * y;
 ----
 
 [float]
@@ -49,7 +49,7 @@ x *= y;   // equivalent to the expression x = x * y;
 [source,arduino]
 ----
 x = 2;
-x *= 2;      // x now contains 4
+x *= 2; // x now contains 4
 ----
 
 

--- a/Language/Structure/Compound Operators/compoundSubtraction.adoc
+++ b/Language/Structure/Compound Operators/compoundSubtraction.adoc
@@ -26,7 +26,7 @@ This is a convenient shorthand to perform subtraction of a constant or a variabl
 === Syntax
 [source,arduino]
 ----
-x -= y;   // equivalent to the expression x = x - y;
+x -= y; // equivalent to the expression x = x - y;
 ----
 
 [float]
@@ -49,7 +49,7 @@ x -= y;   // equivalent to the expression x = x - y;
 [source,arduino]
 ----
 x = 20;
-x -= 2;      // x now contains 18
+x -= 2; // x now contains 18
 ----
 
 

--- a/Language/Structure/Compound Operators/decrement.adoc
+++ b/Language/Structure/Compound Operators/decrement.adoc
@@ -26,8 +26,8 @@ Decrements the value of a variable by 1.
 === Syntax
 [source,arduino]
 ----
-x-- ;   // decrement x by one and returns the old value of x
---x ;   // decrement x by one and returns the new value of x
+x--;  // decrement x by one and returns the old value of x
+--x;  // decrement x by one and returns the new value of x
 ----
 
 [float]
@@ -53,8 +53,8 @@ The original or newly decremented value of the variable.
 [source,arduino]
 ----
 x = 2;
-y = --x;      // x now contains 1, y contains 1
-y = x--;      // x contains 0, but y still contains 1
+y = --x;  // x now contains 1, y contains 1
+y = x--;  // x contains 0, but y still contains 1
 ----
 
 --

--- a/Language/Structure/Compound Operators/increment.adoc
+++ b/Language/Structure/Compound Operators/increment.adoc
@@ -53,8 +53,8 @@ The original or newly incremented value of the variable.
 [source,arduino]
 ----
 x = 2;
-y = ++x;      // x now contains 3, y contains 3
-y = x++;      // x contains 4, but y still contains 3
+y = ++x;  // x now contains 3, y contains 3
+y = x++;  // x contains 4, but y still contains 3
 ----
 
 --

--- a/Language/Structure/Control Structure/break.adoc
+++ b/Language/Structure/Control Structure/break.adoc
@@ -36,15 +36,14 @@ In the following code, the control exits the `for` loop when the sensor value ex
 [source,arduino]
 ----
 int threshold = 40;
-for (x = 0; x < 255; x ++)
-{
-    analogWrite(PWMpin, x);
-    sens = analogRead(sensorPin);
-    if (sens > threshold){      // bail out on sensor detect
-       x = 0;
-       break;
-    }
-    delay(50);
+for (x = 0; x < 255; x ++) {
+  analogWrite(PWMpin, x);
+  sens = analogRead(sensorPin);
+  if (sens > threshold) {     // bail out on sensor detect
+    x = 0;
+    break;
+  }
+  delay(50);
 }
 ----
 

--- a/Language/Structure/Control Structure/continue.adoc
+++ b/Language/Structure/Control Structure/continue.adoc
@@ -36,14 +36,13 @@ The `continue` statement skips the rest of the current iteration of a loop (link
 The following code writes the value of 0 to 255 to the `PWMpin`, but skips the values in the range of 41 to 119.
 [source,arduino]
 ----
-for (x = 0; x <= 255; x ++)
-{
-    if (x > 40 && x < 120){      // create jump in values
-        continue;
-    }
+for (x = 0; x <= 255; x ++) {
+  if (x > 40 && x < 120) {  // create jump in values
+    continue;
+  }
 
-    analogWrite(PWMpin, x);
-    delay(50);
+  analogWrite(PWMpin, x);
+  delay(50);
 }
 ----
 

--- a/Language/Structure/Control Structure/doWhile.adoc
+++ b/Language/Structure/Control Structure/doWhile.adoc
@@ -24,9 +24,8 @@ The `do...while` loop works in the same manner as the link:../while[while] loop,
 === Syntax
 [source,arduino]
 ----
-do
-{
-    // statement block
+do {
+  // statement block
 } while (condition);
 ----
 The `condition` is a boolean expression that evaluates to `true` or `false`.
@@ -47,11 +46,9 @@ The `condition` is a boolean expression that evaluates to `true` or `false`.
 [source,arduino]
 ----
 int x = 0;
-do
-{
+do {
   delay(50);          // wait for sensors to stabilize
   x = readSensors();  // check the sensors
-
 } while (x < 100);
 ----
 

--- a/Language/Structure/Control Structure/else.adoc
+++ b/Language/Structure/Control Structure/else.adoc
@@ -29,16 +29,13 @@ Note that an `else if` block may be used with or without a terminating `else` bl
 === Syntax
 [source,arduino]
 ----
-if (condition1)
-{
+if (condition1) {
   // do Thing A
 }
-else if (condition2)
-{
+else if (condition2) {
   // do Thing B
 }
-else
-{
+else {
   // do Thing C
 }
 ----
@@ -55,16 +52,13 @@ else
 Below is an extract from a code for temperature sensor system
 [source,arduino]
 ----
-if (temperature >= 70)
-{
+if (temperature >= 70) {
   //Danger! Shut down the system
 }
-else if (temperature >= 60 && temperature < 70)
-{
+else if (temperature >= 60 && temperature < 70) {
   //Warning! User attention required
 }
-else
-{
+else {
   //Safe! Continue usual tasks...
 }
 ----

--- a/Language/Structure/Control Structure/for.adoc
+++ b/Language/Structure/Control Structure/for.adoc
@@ -26,7 +26,7 @@ The `for` statement is used to repeat a block of statements enclosed in curly br
 [source,arduino]
 ----
 for (initialization; condition; increment) {
-	//statement(s);
+  // statement(s);
 }
 ----
 
@@ -48,19 +48,17 @@ The *initialization* happens first and exactly once. Each time through the loop,
 [source,arduino]
 ----
 // Dim an LED using a PWM pin
-int PWMpin = 10; // LED in series with 470 ohm resistor on pin 10
+int PWMpin = 10;  // LED in series with 470 ohm resistor on pin 10
 
-void setup()
-{
+void setup() {
   // no setup needed
 }
 
-void loop()
-{
-   for (int i=0; i <= 255; i++){
-      analogWrite(PWMpin, i);
-      delay(10);
-   }
+void loop() {
+  for (int i = 0; i <= 255; i++) {
+    analogWrite(PWMpin, i);
+    delay(10);
+  }
 }
 ----
 [%hardbreaks]
@@ -74,8 +72,8 @@ For example, using a multiplication in the increment line will generate a logari
 
 [source,arduino]
 ----
-for(int x = 2; x < 100; x = x * 1.5){
-println(x);
+for (int x = 2; x < 100; x = x * 1.5) {
+  println(x);
 }
 ----
 
@@ -86,14 +84,15 @@ Another example, fade an LED up and down with one `for` loop:
 
 [source,arduino]
 ----
-void loop()
-{
-   int x = 1;
-   for (int i = 0; i > -1; i = i + x){
-      analogWrite(PWMpin, i);
-      if (i == 255) x = -1;             // switch direction at peak
-      delay(10);
-   }
+void loop() {
+  int x = 1;
+  for (int i = 0; i > -1; i = i + x) {
+    analogWrite(PWMpin, i);
+    if (i == 255) {
+      x = -1;  // switch direction at peak
+    }
+    delay(10);
+  }
 }
 ----
 

--- a/Language/Structure/Control Structure/goto.adoc
+++ b/Language/Structure/Control Structure/goto.adoc
@@ -45,13 +45,15 @@ goto label; // sends program flow to the label
 
 [source,arduino]
 ----
-for(byte r = 0; r < 255; r++){
-    for(byte g = 255; g > 0; g--){
-        for(byte b = 0; b < 255; b++){
-            if (analogRead(0) > 250){ goto bailout;}
-            // more statements ...
-        }
+for (byte r = 0; r < 255; r++) {
+  for (byte g = 255; g > 0; g--) {
+    for (byte b = 0; b < 255; b++) {
+      if (analogRead(0) > 250) {
+        goto bailout;
+      }
+      // more statements ...
     }
+  }
 }
 
 bailout:

--- a/Language/Structure/Control Structure/if.adoc
+++ b/Language/Structure/Control Structure/if.adoc
@@ -23,8 +23,7 @@ The `if` statement checks for a condition and executes the proceeding statement 
 === Syntax
 [source,arduino]
 ----
-if (condition)
-{
+if (condition) {
   //statement(s)
 }
 ----
@@ -46,12 +45,13 @@ if (x > 120) digitalWrite(LEDpin, HIGH);
 if (x > 120)
 digitalWrite(LEDpin, HIGH);
 
-if (x > 120){ digitalWrite(LEDpin, HIGH); }
+if (x > 120) {digitalWrite(LEDpin, HIGH);}
 
-if (x > 120){
+if (x > 120) {
   digitalWrite(LEDpin1, HIGH);
   digitalWrite(LEDpin2, HIGH);
-}                                 // all are correct
+}
+// all are correct
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Control Structure/return.adoc
+++ b/Language/Structure/Control Structure/return.adoc
@@ -51,27 +51,26 @@ A function to compare a sensor input to a threshold
 
 [source,arduino]
 ----
- int checkSensor(){
-    if (analogRead(0) > 400) {
-        return 1;
-    }
-    else{
-        return 0;
-    }
+int checkSensor() {
+  if (analogRead(0) > 400) {
+    return 1;
+  }
+  else {
+    return 0;
+  }
 }
 ----
 
 The return keyword is handy to test a section of code without having to "comment out" large sections of possibly buggy code.
 [source,arduino]
 ----
-void loop(){
+void loop() {
+  // brilliant code idea to test here
 
-// brilliant code idea to test here
+  return;
 
-return;
-
-// the rest of a dysfunctional sketch here
-// this code will never be executed
+  // the rest of a dysfunctional sketch here
+  // this code will never be executed
 }
 ----
 [%hardbreaks]

--- a/Language/Structure/Control Structure/switchCase.adoc
+++ b/Language/Structure/Control Structure/switchCase.adoc
@@ -66,18 +66,18 @@ Nothing
 
 [source,arduino]
 ----
-  switch (var) {
-    case 1:
-      //do something when var equals 1
-      break;
-    case 2:
-      //do something when var equals 2
-      break;
-    default:
-      // if nothing else matches, do the default
-      // default is optional
-      break;
-  }
+switch (var) {
+  case 1:
+    //do something when var equals 1
+    break;
+  case 2:
+    //do something when var equals 2
+    break;
+  default:
+    // if nothing else matches, do the default
+    // default is optional
+    break;
+}
 
 ----
 [%hardbreaks]

--- a/Language/Structure/Control Structure/while.adoc
+++ b/Language/Structure/Control Structure/while.adoc
@@ -24,7 +24,7 @@ A `while` loop will loop continuously, and infinitely, until the expression insi
 === Syntax
 [source,arduino]
 ----
-while(condition){
+while (condition) {
   // statement(s)
 }
 ----
@@ -46,7 +46,7 @@ The `condition` is a boolean expression that evaluates to `true` or `false`.
 [source,arduino]
 ----
 var = 0;
-while(var < 200){
+while (var < 200) {
   // do something repetitive 200 times
   var++;
 }

--- a/Language/Structure/Further Syntax/blockComment.adoc
+++ b/Language/Structure/Further Syntax/blockComment.adoc
@@ -50,8 +50,8 @@ The beginning of a *block comment* or a *multi-line comment* is marked by the sy
 */
 
 /*
-  if (gwb == 0){   // single line comment is OK inside a multi-line comment
-  x = 3;           /* but not another multi-line comment - this is invalid */
+  if (gwb == 0) { // single line comment is OK inside a multi-line comment
+    x = 3;          /* but not another multi-line comment - this is invalid */
   }
 // don't forget the "closing" comment - they have to be balanced!
 */

--- a/Language/Structure/Further Syntax/curlyBraces.adoc
+++ b/Language/Structure/Further Syntax/curlyBraces.adoc
@@ -45,7 +45,7 @@ The main uses of curly braces are listed in the examples below.
 
 [source,arduino]
 ----
-void myfunction(datatype argument){
+void myfunction(datatype argument) {
   // any statement(s)
 }
 ----
@@ -57,18 +57,15 @@ void myfunction(datatype argument){
 
 [source,arduino]
 ----
-while (boolean expression)
-{
+while (boolean expression) {
   // any statement(s)
 }
 
-do
-{
+do {
   // any statement(s)
 } while (boolean expression);
 
-for (initialisation; termination condition; incrementing expr)
-{
+for (initialisation; termination condition; incrementing expr) {
   // any statement(s)
 }
 ----
@@ -82,17 +79,14 @@ for (initialisation; termination condition; incrementing expr)
 
 [source,arduino]
 ----
-if (boolean expression)
-{
+if (boolean expression) {
   // any statement(s)
 }
 
-else if (boolean expression)
-{
+else if (boolean expression) {
   // any statement(s)
 }
-else
-{
+else {
   // any statement(s)
 }
 ----

--- a/Language/Structure/Further Syntax/define.adoc
+++ b/Language/Structure/Further Syntax/define.adoc
@@ -62,14 +62,14 @@ There is no semicolon after the #define statement. If you include one, the compi
 
 [source,arduino]
 ----
-#define ledPin 3;    // this is an error
+#define ledPin 3; // this is an error
 ----
 
 Similarly, including an equal sign after the #define statement will also generate a cryptic compiler error further down the page.
 
 [source,arduino]
 ----
-#define ledPin  = 3  // this is also an error
+#define ledPin  = 3 // this is also an error
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Further Syntax/singleLineComment.adoc
+++ b/Language/Structure/Further Syntax/singleLineComment.adoc
@@ -38,12 +38,10 @@ There are two different ways of marking a line as a comment:
 
 [source,arduino]
 ----
-// Pin 13 has an LED connected on most Arduino boards.
+// pin 13 has an LED connected on most Arduino boards.
 // give it a name:
 int led = 13;
-
-
-digitalWrite(led, HIGH);   // turn the LED on (HIGH is the voltage level)
+digitalWrite(led, HIGH);  // turn the LED on (HIGH is the voltage level)
 ----
 [%hardbreaks]
 

--- a/Language/Structure/Pointer Access Operators/dereference.adoc
+++ b/Language/Structure/Pointer Access Operators/dereference.adoc
@@ -36,7 +36,8 @@ Dereferencing is one of the features specifically for use with pointers. The ast
 [source,arduino]
 ----
 int *p;       // declare a pointer to an int data type
-int i = 5, result = 0;
+int i = 5;
+int result = 0;
 p = &i;       // now 'p' contains the address of 'i'
 result = *p;  // 'result' gets the value at the address pointed by 'p'
               // i.e., it gets the value of 'i' which is 5

--- a/Language/Structure/Pointer Access Operators/reference.adoc
+++ b/Language/Structure/Pointer Access Operators/reference.adoc
@@ -36,7 +36,8 @@ Referencing is one of the features specifically for use with pointers. The amper
 [source,arduino]
 ----
 int *p;       // declare a pointer to an int data type
-int i = 5, result = 0;
+int i = 5;
+int result = 0;
 p = &i;       // now 'p' contains the address of 'i'
 result = *p;  // 'result' gets the value at the address pointed by 'p'
               // i.e., it gets the value of 'i' which is 5

--- a/Language/Structure/Sketch/loop.adoc
+++ b/Language/Structure/Sketch/loop.adoc
@@ -35,20 +35,20 @@ After creating a link:../setup[setup()] function, which initializes and sets the
 int buttonPin = 3;
 
 // setup initializes serial and the button pin
-void setup()
-{
+void setup() {
   Serial.begin(9600);
   pinMode(buttonPin, INPUT);
 }
 
 // loop checks the button pin each time,
 // and will send serial if it is pressed
-void loop()
-{
-  if (digitalRead(buttonPin) == HIGH)
+void loop() {
+  if (digitalRead(buttonPin) == HIGH) {
     Serial.write('H');
-  else
+  }
+  else {
     Serial.write('L');
+  }
 
   delay(1000);
 }

--- a/Language/Structure/Sketch/setup.adoc
+++ b/Language/Structure/Sketch/setup.adoc
@@ -35,14 +35,12 @@ The `setup()` function is called when a sketch starts. Use it to initialize vari
 ----
 int buttonPin = 3;
 
-void setup()
-{
+void setup() {
   Serial.begin(9600);
   pinMode(buttonPin, INPUT);
 }
 
-void loop()
-{
+void loop() {
   // ...
 }
 ----

--- a/Language/Variables/Constants/integerConstants.adoc
+++ b/Language/Variables/Constants/integerConstants.adoc
@@ -64,7 +64,7 @@ This is the common-sense math with which you are acquainted. Constants without o
 === Example  Code:
 [source,arduino]
 ----
-n = 101;     // same as 101 decimal   ((1 * 10^2) + (0 * 10^1) + 1)
+n = 101;  // same as 101 decimal ((1 * 10^2) + (0 * 10^1) + 1)
 ----
 [%hardbreaks]
 
@@ -76,13 +76,13 @@ Only the characters 0 and 1 are valid.
 === Example  Code:
 [source,arduino]
 ----
-n = B101;    // same as 5 decimal   ((1 * 2^2) + (0 * 2^1) + 1)
+n = B101; // same as 5 decimal ((1 * 2^2) + (0 * 2^1) + 1)
 ----
 
 The binary formatter only works on bytes (8 bits) between 0 (B0) and 255 (B11111111). If it is convenient to input an int (16 bits) in binary form you can do it a two-step procedure such as:
 [source,arduino]
 ----
-myInt = (B11001100 * 256) + B10101010;    // B11001100 is the high byte`
+myInt = (B11001100 * 256) + B10101010;  // B11001100 is the high byte`
 ----
 [%hardbreaks]
 
@@ -94,7 +94,7 @@ Only the characters 0 through 7 are valid. Octal values are indicated by the pre
 === Example  Code:
 [source,arduino]
 ----
-n = 0101;    // same as 65 decimal   ((1 * 8^2) + (0 * 8^1) + 1)
+n = 0101; // same as 65 decimal ((1 * 8^2) + (0 * 8^1) + 1)
 ----
 It is possible to generate a hard-to-find bug by (unintentionally) including a leading zero before a constant and having the compiler unintentionally interpret your constant as octal.
 [%hardbreaks]
@@ -107,7 +107,7 @@ Valid characters are 0 through 9 and letters A through F; A has the value 10, B 
 === Example  Code:
 [source,arduino]
 ----
-n = 0x101;   // same as 257 decimal   ((1 * 16^2) + (0 * 16^1) + 1)
+n = 0x101;  // same as 257 decimal ((1 * 16^2) + (0 * 16^1) + 1)
 ----
 [%hardbreaks]
 

--- a/Language/Variables/Data Types/String/Functions/reserve.adoc
+++ b/Language/Variables/Data Types/String/Functions/reserve.adoc
@@ -67,9 +67,8 @@ void setup() {
 }
 
 void loop() {
- // nothing to do here
+  // nothing to do here
 }
- 
 ----
 // HOW TO USE SECTION ENDS
 

--- a/Language/Variables/Data Types/array.adoc
+++ b/Language/Variables/Data Types/array.adoc
@@ -46,9 +46,9 @@ It also means that in an array with ten elements, index nine is the last element
 
 [source,arduino]
 ----
-int myArray[10]={9,3,2,4,3,2,7,8,9,11};
-     // myArray[9]    contains 11
-     // myArray[10]   is invalid and contains random information (other memory address)
+int myArray[10]={9, 3, 2, 4, 3, 2, 7, 8, 9, 11};
+// myArray[9]    contains 11
+// myArray[10]   is invalid and contains random information (other memory address)
 ----
 For this reason you should be careful in accessing arrays. Accessing past the end of an array (using an index number greater than your declared array size - 1) is reading from memory that is in use for other purposes. Reading from these locations is probably not going to do much except yield invalid data. Writing to random memory locations is definitely a bad idea and can often lead to unhappy results such as crashes or program malfunction. This can also be a difficult bug to track down.
 [%hardbreaks]

--- a/Language/Variables/Data Types/bool.adoc
+++ b/Language/Variables/Data Types/bool.adoc
@@ -50,25 +50,23 @@ This code shows how to use the `bool` datatype.
 
 [source,arduino]
 ----
-int LEDpin = 5;       // LED on pin 5
-int switchPin = 13;   // momentary switch on 13, other side connected to ground
+int LEDpin = 5;     // LED on pin 5
+int switchPin = 13; // momentary switch on 13, other side connected to ground
 
 bool running = false;
 
-void setup()
-{
+void setup() {
   pinMode(LEDpin, OUTPUT);
   pinMode(switchPin, INPUT);
-  digitalWrite(switchPin, HIGH);      // turn on pullup resistor
+  digitalWrite(switchPin, HIGH);  // turn on pullup resistor
 }
 
-void loop()
-{
-  if (digitalRead(switchPin) == LOW)
-  {  // switch is pressed - pullup keeps pin high normally
-    delay(100);                        // delay to debounce switch
-    running = !running;                // toggle running variable
-    digitalWrite(LEDpin, running);     // indicate via LED
+void loop() {
+  if (digitalRead(switchPin) == LOW) {
+    // switch is pressed - pullup keeps pin high normally
+    delay(100);                     // delay to debounce switch
+    running = !running;             // toggle running variable
+    digitalWrite(LEDpin, running);  // indicate via LED
   }
 }
 ----

--- a/Language/Variables/Data Types/char.adoc
+++ b/Language/Variables/Data Types/char.adoc
@@ -51,8 +51,8 @@ The size of the `char` datatype is at least 8 bits. It's recommended to only use
 
 [source,arduino]
 ----
-  char myChar = 'A';
-  char myChar = 65;      // both are equivalent
+char myChar = 'A';
+char myChar = 65; // both are equivalent
 ----
 
 

--- a/Language/Variables/Data Types/float.adoc
+++ b/Language/Variables/Data Types/float.adoc
@@ -30,7 +30,7 @@ If doing math with floats, you need to add a decimal point, otherwise it will be
 
 [float]
 === Syntax
-`float var=val;`
+`float var = val;`
 
 `var` - your float variable name
 `val` - the value you assign to that variable
@@ -53,16 +53,16 @@ If doing math with floats, you need to add a decimal point, otherwise it will be
 
 [source,arduino]
 ----
-  float myfloat;
-  float sensorCalbrate = 1.117;
+float myfloat;
+float sensorCalbrate = 1.117;
 
-  int x;
-  int y;
-  float z;
+int x;
+int y;
+float z;
 
-  x = 1;
-  y = x / 2;            // y now contains 0, ints can't hold fractions
-  z = (float)x / 2.0;   // z now contains .5 (you have to use 2.0, not 2)
+x = 1;
+y = x / 2;          // y now contains 0, ints can't hold fractions
+z = (float)x / 2.0; // z now contains .5 (you have to use 2.0, not 2)
 ----
 
 

--- a/Language/Variables/Data Types/int.adoc
+++ b/Language/Variables/Data Types/int.adoc
@@ -57,7 +57,7 @@ void setup() {
 void loop() {
   countUp++;                //Adds 1 to the countUp int on every loop
   Serial.println(countUp);  // prints out the current state of countUp
-  delay(1000);              
+  delay(1000);
 }
 ----
 [%hardbreaks]

--- a/Language/Variables/Data Types/long.adoc
+++ b/Language/Variables/Data Types/long.adoc
@@ -47,7 +47,7 @@ If doing math with integers, at least one of the numbers must be followed by an 
 
 [source,arduino]
 ----
-  long speedOfLight = 186000L;   // see the Integer Constants page for explanation of the 'L'
+long speedOfLight = 186000L;  // see the Integer Constants page for explanation of the 'L'
 ----
 
 --

--- a/Language/Variables/Data Types/short.adoc
+++ b/Language/Variables/Data Types/short.adoc
@@ -45,7 +45,7 @@ On all Arduinos (ATMega and ARM based) a short stores a 16-bit (2-byte) value. T
 
 [source,arduino]
 ----
- short ledPin = 13
+short ledPin = 13
 ----
 
 --

--- a/Language/Variables/Data Types/string.adoc
+++ b/Language/Variables/Data Types/string.adoc
@@ -27,7 +27,7 @@ All of the following are valid declarations for strings.
 `char Str1[15];` +
 `char Str2[8] = {'a', 'r', 'd', 'u', 'i', 'n', 'o'};` +
 `char Str3[8] = {'a', 'r', 'd', 'u', 'i', 'n', 'o', '\0'};` +
-`char Str4[ ] = "arduino";` +
+`char Str4[] = "arduino";` +
 `char Str5[8] = "arduino";` +
 `char Str6[15] = "arduino";`
 
@@ -86,18 +86,19 @@ In the code below, the asterisk after the datatype `char` "`char*`" indicates th
 
 [source,arduino]
 ----
-char* myStrings[]={"This is string 1", "This is string 2", "This is string 3",
-"This is string 4", "This is string 5","This is string 6"};
+char *myStrings[] = {"This is string 1", "This is string 2", "This is string 3",
+                     "This is string 4", "This is string 5", "This is string 6"
+                    };
 
-void setup(){
-Serial.begin(9600);
+void setup() {
+  Serial.begin(9600);
 }
 
-void loop(){
-for (int i = 0; i < 6; i++){
-   Serial.println(myStrings[i]);
-   delay(500);
-   }
+void loop() {
+  for (int i = 0; i < 6; i++) {
+    Serial.println(myStrings[i]);
+    delay(500);
+  }
 }
 ----
 

--- a/Language/Variables/Data Types/stringObject.adoc
+++ b/Language/Variables/Data Types/stringObject.adoc
@@ -85,16 +85,16 @@ an instance of the String class.
 All of the following are valid declarations for Strings.
 [source,arduino]
 ----
-String stringOne = "Hello String";                        // using a constant String
-String stringOne =  String('a');                          // converting a constant char into a String
-String stringTwo =  String("This is a string");           // converting a constant string into a String object
-String stringOne =  String(stringTwo + " with more");     // concatenating two strings
-String stringOne =  String(13);                           // using a constant integer
-String stringOne =  String(analogRead(0), DEC);           // using an int and a base
-String stringOne =  String(45, HEX);                      // using an int and a base (hexadecimal)
-String stringOne =  String(255, BIN);                     // using an int and a base (binary)
-String stringOne =  String(millis(), DEC);                // using a long and a base
-String stringOne =  String(5.698, 3);                     // using a float and the decimal places
+String stringOne = "Hello String";                    // using a constant String
+String stringOne = String('a');                       // converting a constant char into a String
+String stringTwo = String("This is a string");        // converting a constant string into a String object
+String stringOne = String(stringTwo + " with more");  // concatenating two strings
+String stringOne = String(13);                        // using a constant integer
+String stringOne = String(analogRead(0), DEC);        // using an int and a base
+String stringOne = String(45, HEX);                   // using an int and a base (hexadecimal)
+String stringOne = String(255, BIN);                  // using an int and a base (binary)
+String stringOne = String(millis(), DEC);             // using a long and a base
+String stringOne = String(5.698, 3);                  // using a float and the decimal places
 ----
 
 --

--- a/Language/Variables/Data Types/unsignedInt.adoc
+++ b/Language/Variables/Data Types/unsignedInt.adoc
@@ -45,7 +45,7 @@ The difference between unsigned ints and (signed) ints, lies in the way the high
 
 [source,arduino]
 ----
-  unsigned int ledPin = 13;
+unsigned int ledPin = 13;
 ----
 [%hardbreaks]
 
@@ -56,9 +56,9 @@ When unsigned variables are made to exceed their maximum capacity they "roll ove
 [source,arduino]
 ----
 unsigned int x;
-   x = 0;
-   x = x - 1;       // x now contains 65535 - rolls over in neg direction
-   x = x + 1;       // x now contains 0 - rolls over
+x = 0;
+x = x - 1;  // x now contains 65535 - rolls over in neg direction
+x = x + 1;  // x now contains 0 - rolls over
 ----
 
 Math with unsigned variables may produce unexpected results, even if your unsigned variable never rolls over.
@@ -72,16 +72,16 @@ However with a calculation which requires an intermediate result, the scope of t
 
 [source,arduino]
 ----
-unsigned int x=5;
-unsigned int y=10;
+unsigned int x = 5;
+unsigned int y = 10;
 int result;
 
-   result = x - y; // 5 - 10 = -5, as expected
-   result = (x - y)/2; // 5 - 10 in unsigned math is 65530!  65530/2 = 32765 
-   
-   // solution: use signed variables, or do the calculation step by step.
-   result = x - y; // 5 - 10 = -5, as expected
-   result = result / 2; //  -5/2 = -2 (only integer math, decimal places are dropped)
+result = x - y; // 5 - 10 = -5, as expected
+result = (x - y) / 2; // 5 - 10 in unsigned math is 65530!  65530/2 = 32765
+
+// solution: use signed variables, or do the calculation step by step.
+result = x - y; // 5 - 10 = -5, as expected
+result = result / 2;  //  -5/2 = -2 (only integer math, decimal places are dropped)
 ----
 Why use unsigned variables at all?
 

--- a/Language/Variables/Data Types/unsignedLong.adoc
+++ b/Language/Variables/Data Types/unsignedLong.adoc
@@ -48,13 +48,11 @@ Unsigned long variables are extended size variables for number storage, and stor
 ----
 unsigned long time;
 
-void setup()
-{
+void setup() {
   Serial.begin(9600);
 }
 
-void loop()
-{
+void loop() {
   Serial.print("Time: ");
   time = millis();
   //prints time since program started

--- a/Language/Variables/Data Types/void.adoc
+++ b/Language/Variables/Data Types/void.adoc
@@ -40,13 +40,11 @@ The code shows how to use `void`.
 // actions are performed in the functions "setup" and "loop"
 // but  no information is reported to the larger program
 
-void setup()
-{
+void setup() {
   // ...
 }
 
-void loop()
-{
+void loop() {
   // ...
 }
 ----

--- a/Language/Variables/Data Types/word.adoc
+++ b/Language/Variables/Data Types/word.adoc
@@ -48,7 +48,7 @@ A word can store an unsigned number of at least 16 bits (from 0 to 65535).
 
 [source,arduino]
 ----
-  word w = 10000;
+word w = 10000;
 ----
 
 --

--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -37,9 +37,9 @@ const dataType variableName[] PROGMEM = {data0, data1, data3...};
 
 Note that because PROGMEM is a variable modifier, there is no hard and fast rule about where it should go, so the Arduino compiler accepts all of the definitions below, which are also synonymous. However experiments have indicated that, in various versions of Arduino (having to do with GCC version), PROGMEM may work in one location and not in another. The "string table" example below has been tested to work with Arduino 13. Earlier versions of the IDE may work better if PROGMEM is included after the variable name.
 
-`const dataType variableName[] PROGMEM = {};   // use this form` +
-`const PROGMEM  dataType  variableName[] = {}; // or this one` +
-`const dataType PROGMEM variableName[] = {};   // not this one`
+`const dataType variableName[] PROGMEM = {};  // use this form` +
+`const PROGMEM dataType variableName[] = {};  // or this one` +
+`const dataType PROGMEM variableName[] = {};  // not this one`
 
 
 While `PROGMEM` could be used on a single variable, it is really only worth the fuss if you have a larger block of data that needs to be stored, which is usually easiest in an array, (or another C++ data structure beyond our present discussion).
@@ -71,7 +71,7 @@ const PROGMEM  uint16_t charSet[]  = { 65000, 32796, 16843, 10, 11234};
 const char signMessage[] PROGMEM  = {"I AM PREDATOR,  UNSEEN COMBATANT. CREATED BY THE UNITED STATES DEPART"};
 
 unsigned int displayInt;
-int k;    // counter variable
+int k;  // counter variable
 char myChar;
 
 
@@ -81,16 +81,14 @@ void setup() {
 
   // put your setup code here, to run once:
   // read back a 2-byte int
-  for (k = 0; k < 5; k++)
-  {
+  for (k = 0; k < 5; k++) {
     displayInt = pgm_read_word_near(charSet + k);
     Serial.println(displayInt);
   }
   Serial.println();
 
   // read back a char
-  for (k = 0; k < strlen_P(signMessage); k++)
-  {
+  for (k = 0; k < strlen_P(signMessage); k++) {
     myChar =  pgm_read_byte_near(signMessage + k);
     Serial.print(myChar);
   }
@@ -100,7 +98,6 @@ void setup() {
 
 void loop() {
   // put your main code here, to run repeatedly:
-
 }
 
 ----
@@ -113,21 +110,21 @@ These tend to be large structures so putting them into program memory is often d
 [source,arduino]
 ----
 /*
- PROGMEM string demo
- How to store a table of strings in program memory (flash),
- and retrieve them.
+  PROGMEM string demo
+  How to store a table of strings in program memory (flash),
+  and retrieve them.
 
- Information summarized from:
- http://www.nongnu.org/avr-libc/user-manual/pgmspace.html
+  Information summarized from:
+  http://www.nongnu.org/avr-libc/user-manual/pgmspace.html
 
- Setting up a table (array) of strings in program memory is slightly complicated, but
- here is a good template to follow.
+  Setting up a table (array) of strings in program memory is slightly complicated, but
+  here is a good template to follow.
 
- Setting up the strings is a two-step process. First define the strings.
+  Setting up the strings is a two-step process. First define the strings.
 */
 
 #include <avr/pgmspace.h>
-const char string_0[] PROGMEM = "String 0";   // "String 0" etc are strings to store - change to suit.
+const char string_0[] PROGMEM = "String 0"; // "String 0" etc are strings to store - change to suit.
 const char string_1[] PROGMEM = "String 1";
 const char string_2[] PROGMEM = "String 2";
 const char string_3[] PROGMEM = "String 3";
@@ -137,34 +134,30 @@ const char string_5[] PROGMEM = "String 5";
 
 // Then set up a table to refer to your strings.
 
-const char* const string_table[] PROGMEM = {string_0, string_1, string_2, string_3, string_4, string_5};
+const char *const string_table[] PROGMEM = {string_0, string_1, string_2, string_3, string_4, string_5};
 
-char buffer[30];    // make sure this is large enough for the largest string it must hold
+char buffer[30];  // make sure this is large enough for the largest string it must hold
 
-void setup()
-{
+void setup() {
   Serial.begin(9600);
-  while(!Serial); // wait for serial port to connect. Needed for native USB
+  while (!Serial);  // wait for serial port to connect. Needed for native USB
   Serial.println("OK");
 }
 
 
-void loop()
-{
+void loop() {
   /* Using the string table in program memory requires the use of special functions to retrieve the data.
      The strcpy_P function copies a string from program space to a string in RAM ("buffer").
      Make sure your receiving string in RAM  is large enough to hold whatever
      you are retrieving from program space. */
 
 
-  for (int i = 0; i < 6; i++)
-  {
-    strcpy_P(buffer, (char*)pgm_read_word(&(string_table[i]))); // Necessary casts and dereferencing, just copy.
+  for (int i = 0; i < 6; i++) {
+    strcpy_P(buffer, (char *)pgm_read_word(&(string_table[i])));  // Necessary casts and dereferencing, just copy.
     Serial.println(buffer);
-    delay( 500 );
+    delay(500);
   }
 }
-
 ----
 [%hardbreaks]
 

--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -48,18 +48,18 @@ This program prints out a text string one character at a time. Try changing the 
 char myStr[] = "this is a test";
 int i;
 
-void setup(){
+void setup() {
   Serial.begin(9600);
 }
 
 void loop() {
-  for (i = 0; i < sizeof(myStr) - 1; i++){
+  for (i = 0; i < sizeof(myStr) - 1; i++) {
     Serial.print(i, DEC);
     Serial.print(" = ");
     Serial.write(myStr[i]);
     Serial.println();
   }
-  delay(5000); // slow down the program
+  delay(5000);  // slow down the program
 }
 ----
 [%hardbreaks]
@@ -73,7 +73,7 @@ Note that `sizeof` returns the total number of bytes. So for arrays of larger va
 int myValues[] = {123, 456, 789};
 
 // this for loop works correctly with an array of any type or size
-for (i = 0; i < (sizeof(myValues)/sizeof(myValues[0])); i++) {
+for (i = 0; i < (sizeof(myValues) / sizeof(myValues[0])); i++) {
   // do something with myValues[i]
 }
 ----

--- a/Language/Variables/Variable Scope & Qualifiers/const.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/const.adoc
@@ -41,14 +41,9 @@ Constants defined with the `const` keyword obey the rules of link:../scope[varia
 ----
 const float pi = 3.14;
 float x;
-
 // ....
-
-x = pi * 2;    // it's fine to use consts in math
-
-pi = 7;        // illegal - you can't write to (modify) a constant
-
-
+x = pi * 2; // it's fine to use consts in math
+pi = 7;     // illegal - you can't write to (modify) a constant
 ----
 [%hardbreaks]
 

--- a/Language/Variables/Variable Scope & Qualifiers/scope.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/scope.adoc
@@ -45,21 +45,18 @@ It is also sometimes handy to declare and initialize a variable inside a `for` l
 ----
 int gPWMval;  // any function will see this variable
 
-void setup()
-{
+void setup() {
   // ...
 }
 
-void loop()
-{
+void loop() {
   int i;    // "i" is only "visible" inside of "loop"
   float f;  // "f" is only "visible" inside of "loop"
   // ...
 
-  for (int j = 0; j <100; j++){
-  // variable j can only be accessed inside the for-loop brackets
+  for (int j = 0; j < 100; j++) {
+    // variable j can only be accessed inside the for-loop brackets
   }
-
 }
 ----
 [%hardbreaks]

--- a/Language/Variables/Variable Scope & Qualifiers/static.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/static.adoc
@@ -36,12 +36,12 @@ Variables declared as static will only be created and initialized the first time
 [source,arduino]
 ----
 /* RandomWalk
-* Paul Badger 2007
-* RandomWalk wanders up and down randomly between two
-* endpoints. The maximum move in one loop is governed by
-* the parameter "stepsize".
-* A static variable is moved up and down a random amount.
-* This technique is also known as "pink noise" and "drunken walk".
+  Paul Badger 2007
+  RandomWalk wanders up and down randomly between two
+  endpoints. The maximum move in one loop is governed by
+  the parameter "stepsize".
+  A static variable is moved up and down a random amount.
+  This technique is also known as "pink noise" and "drunken walk".
 */
 
 #define randomWalkLowRange -20
@@ -50,29 +50,28 @@ int stepsize;
 
 int thisTime;
 
-void setup()
-{
+void setup() {
   Serial.begin(9600);
 }
 
-void loop()
-{        //  test randomWalk function
+void loop() {
+  //  test randomWalk function
   stepsize = 5;
   thisTime = randomWalk(stepsize);
   Serial.println(thisTime);
-   delay(10);
+  delay(10);
 }
 
-int randomWalk(int moveSize){
-  static int  place;     // variable to store value in random walk - declared static so that it stores
-                         // values in between function calls, but no other functions can change its value
+int randomWalk(int moveSize) {
+  static int place; // variable to store value in random walk - declared static so that it stores
+  // values in between function calls, but no other functions can change its value
 
   place = place + (random(-moveSize, moveSize + 1));
 
-  if (place < randomWalkLowRange){                              // check lower and upper limits
-    place = randomWalkLowRange + (randomWalkLowRange - place);  // reflect number back in positive direction
+  if (place < randomWalkLowRange) {                               // check lower and upper limits
+    place = randomWalkLowRange + (randomWalkLowRange - place);    // reflect number back in positive direction
   }
-  else if(place > randomWalkHighRange){
+  else if (place > randomWalkHighRange) {
     place = randomWalkHighRange - (place - randomWalkHighRange);  // reflect number back in negative direction
   }
 

--- a/Language/Variables/Variable Scope & Qualifiers/volatile.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/volatile.adoc
@@ -63,22 +63,18 @@ There are several ways to do this:
 int pin = 13;
 volatile byte state = LOW;
 
-void setup()
-{
+void setup() {
   pinMode(pin, OUTPUT);
   attachInterrupt(digitalPinToInterrupt(2), blink, CHANGE);
 }
 
-void loop()
-{
+void loop() {
   digitalWrite(pin, state);
 }
 
-void blink()
-{
+void blink() {
   state = !state;
 }
-
 ----
 
 
@@ -88,10 +84,9 @@ void blink()
 volatile int input_from_interrupt;
 
   ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-     // code with interrupts blocked (consecutive atomic operations will not get interrupted)
-     int result = input_from_interrupt;
-   }
-
+    // code with interrupts blocked (consecutive atomic operations will not get interrupted)
+    int result = input_from_interrupt;
+  }
 ----
 
 


### PR DESCRIPTION
Inconsistent code formatting is confusing to beginners who may not understand which code differences are purely aesthetic. Inconsistency also breeds more inconsistency and inefficiency as contributors of example code struggle to determine any style convention to follow in their work.

[AStyle](http://astyle.sourceforge.net/astyle.html) (the tool used for the Arduino IDE's Auto Format feature) was used to automatically format the example code in the reference pages according to the standard Arduino style established in the official example sketches bundled with the Arduino IDE. The Auto Format formatting settings were used in addition to Arduino example formatter configuration:
https://github.com/arduino/Arduino/blob/1.8.8/build/shared/examples_formatter.conf
I used the latest version of AStyle, which offers some new configuration settings that allow enhanced compliance with the Arduino code style:
```
mode=c

style=attach

break-closing-braces
attach-closing-while
attach-namespaces
attach-classes
attach-inlines
attach-extern-c

indent=spaces=2
indent-classes
indent-switches
indent-cases
indent-col1-comments
indent-modifiers
indent-namespaces
indent-labels
indent-preproc-define

pad-header
pad-oper
unpad-paren

add-braces

remove-comment-prefix
convert-tabs
align-pointer=name
```

Partially fixes https://github.com/arduino/Arduino/issues/6503 (the same still needs to be done for library reference pages)