### PR TITLE
Add unsigned int/long type casting pages

### DIFF
--- a/Language/Variables/Conversion/byteCast.adoc
+++ b/Language/Variables/Conversion/byteCast.adoc
@@ -23,7 +23,8 @@ Converts a value to the link:../../data-types/byte[byte] data type.
 
 [float]
 === Syntax
-`byte(x)`
+`byte(x)` +
+`(byte)x` (C-style type conversion)
 
 
 [float]

--- a/Language/Variables/Conversion/charCast.adoc
+++ b/Language/Variables/Conversion/charCast.adoc
@@ -23,7 +23,8 @@ Converts a value to the link:../../data-types/char[char] data type.
 
 [float]
 === Syntax
-`char(x)`
+`char(x)` +
+`(char)x` (C-style type conversion)
 
 
 [float]

--- a/Language/Variables/Conversion/floatCast.adoc
+++ b/Language/Variables/Conversion/floatCast.adoc
@@ -23,7 +23,8 @@ Converts a value to the link:../../data-types/float[float] data type.
 
 [float]
 === Syntax
-`float(x)`
+`float(x)` +
+`(float)x` (C-style type conversion)
 
 
 [float]

--- a/Language/Variables/Conversion/intCast.adoc
+++ b/Language/Variables/Conversion/intCast.adoc
@@ -23,7 +23,8 @@ Converts a value to the link:../../data-types/int[int] data type.
 
 [float]
 === Syntax
-`int(x)`
+`int(x)` +
+`(int)x` (C-style type conversion)
 
 
 [float]

--- a/Language/Variables/Conversion/longCast.adoc
+++ b/Language/Variables/Conversion/longCast.adoc
@@ -23,7 +23,8 @@ Converts a value to the link:../../data-types/long[long] data type.
 
 [float]
 === Syntax
-`long(x)`
+`long(x)` +
+`(long)x` (C-style type conversion)
 
 
 [float]

--- a/Language/Variables/Conversion/unsignedIntCast.adoc
+++ b/Language/Variables/Conversion/unsignedIntCast.adoc
@@ -1,0 +1,55 @@
+---
+title: (unsigned int)
+categories: [ "Variables" ]
+subCategories: [ "Conversion" ]
+---
+
+
+
+
+
+= (unsigned int)
+
+
+// OVERVIEW SECTION STARTS
+[#overview]
+--
+
+[float]
+=== Description
+Converts a value to the link:../../data-types/unsignedint[unsigned int] data type.
+[%hardbreaks]
+
+
+[float]
+=== Syntax
+`(unsigned int)x`
+
+
+[float]
+=== Parameters
+`x`: a value of any type
+
+[float]
+=== Returns
+`unsigned int`
+
+--
+// OVERVIEW SECTION ENDS
+
+
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+[role="language"]
+* #LANGUAGE# link:../../data-types/unsignedint[unsigned int]
+
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Variables/Conversion/unsignedLongCast.adoc
+++ b/Language/Variables/Conversion/unsignedLongCast.adoc
@@ -1,0 +1,55 @@
+---
+title: (unsigned long)
+categories: [ "Variables" ]
+subCategories: [ "Conversion" ]
+---
+
+
+
+
+
+= (unsigned long)
+
+
+// OVERVIEW SECTION STARTS
+[#overview]
+--
+
+[float]
+=== Description
+Converts a value to the link:../../data-types/unsignedlong[unsigned long] data type.
+[%hardbreaks]
+
+
+[float]
+=== Syntax
+`(unsigned long)x`
+
+
+[float]
+=== Parameters
+`x`: a value of any type
+
+[float]
+=== Returns
+`unsigned long`
+
+--
+// OVERVIEW SECTION ENDS
+
+
+
+
+// SEE ALSO SECTION STARTS
+[#see_also]
+--
+
+[float]
+=== See also
+
+[role="language"]
+* #LANGUAGE# link:../../data-types/unsignedlong[unsigned long]
+
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Variables/Conversion/wordcast.adoc
+++ b/Language/Variables/Conversion/wordcast.adoc
@@ -24,7 +24,8 @@ Converts a value to the link:../../data-types/word[word] data type.
 [float]
 === Syntax
 `word(x)` +
-`word(h, l)`
+`word(h, l)` +
+`(word)x` (C-style type conversion)
 
 [float]
 === Parameters


### PR DESCRIPTION
- Use C-like type casting syntax in existing cast pages for consistence, since this syntax is required for `unsigned int/long`
- Add unsigned int/long type casting pages