### PR TITLE
Document syntax for data types where missing

### DIFF
--- a/Language/Variables/Data Types/bool.adoc
+++ b/Language/Variables/Data Types/bool.adoc
@@ -22,6 +22,17 @@ A `bool` holds one of two values, `true` or `false`. (Each `bool` variable occup
 
 [%hardbreaks]
 
+
+[float]
+=== Syntax
+`bool var = val;`
+
+
+[float]
+=== Parameters
+`var`: variable name +
+`val`: the value to assign to that variable
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/byte.adoc
+++ b/Language/Variables/Data Types/byte.adoc
@@ -20,6 +20,17 @@ subCategories: [ "Data Types" ]
 A byte stores an 8-bit unsigned number, from 0 to 255.
 [%hardbreaks]
 
+
+[float]
+=== Syntax
+`byte var = val;`
+
+
+[float]
+=== Parameters
+`var`: variable name +
+`val`: the value to assign to that variable
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/char.adoc
+++ b/Language/Variables/Data Types/char.adoc
@@ -24,6 +24,17 @@ Characters are stored as numbers however. You can see the specific encoding in t
 The char datatype is a signed type, meaning that it encodes numbers from -128 to 127. For an unsigned, one-byte (8 bit) data type, use the _byte_ data type.
 [%hardbreaks]
 
+
+[float]
+=== Syntax
+`char var = val;`
+
+
+[float]
+=== Parameters
+`var`: variable name +
+`val`: the value to assign to that variable
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/double.adoc
+++ b/Language/Variables/Data Types/double.adoc
@@ -22,6 +22,17 @@ Double precision floating point number. On the Uno and other ATMEGA based boards
 On the Arduino Due, doubles have 8-byte (64 bit) precision.
 [%hardbreaks]
 
+
+[float]
+=== Syntax
+`double var = val;`
+
+
+[float]
+=== Parameters
+`var`: variable name +
+`val`: the value to assign to that variable
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/size_t.adoc
+++ b/Language/Variables/Data Types/size_t.adoc
@@ -20,6 +20,17 @@ subCategories: [ "Data Types" ]
 `size_t` is a data type capable of representing the size of any object in bytes. Examples of the use of `size_t` are the return type of link:../../utilities/sizeof[sizeof()] and link:../../../functions/communication/serial/print[Serial.print()].
 [%hardbreaks]
 
+
+[float]
+=== Syntax
+`size_t var = val;`
+
+
+[float]
+=== Parameters
+`var`: variable name +
+`val`: the value to assign to that variable
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/unsignedChar.adoc
+++ b/Language/Variables/Data Types/unsignedChar.adoc
@@ -24,6 +24,17 @@ The unsigned char datatype encodes numbers from 0 to 255.
 For consistency of Arduino programming style, the byte data type is to be preferred.
 [%hardbreaks]
 
+
+[float]
+=== Syntax
+`unsigned char var = val;`
+
+
+[float]
+=== Parameters
+`var`: variable name +
+`val`: the value to assign to that variable
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/word.adoc
+++ b/Language/Variables/Data Types/word.adoc
@@ -20,6 +20,17 @@ subCategories: [ "Data Types" ]
 A word stores a 16-bit unsigned number, from 0 to 65535. Same as an unsigned int.
 [%hardbreaks]
 
+
+[float]
+=== Syntax
+`word var = val;`
+
+
+[float]
+=== Parameters
+`var`: variable name +
+`val`: the value to assign to that variable
+
 --
 // OVERVIEW SECTION ENDS
 


### PR DESCRIPTION
Some of the type reference pages had syntax documentation, others didn't.