### PR TITLE
Separate parameters list with blank lines

### DIFF
--- a/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Single_Entity.adoc
+++ b/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Single_Entity.adoc
@@ -42,7 +42,8 @@ image::http://arduino.cc/en/uploads/Main/ArduinoUno_R3_Front_450px.jpg[caption="
 [float]
 === Parameters
 // List all available parameters, please describe them one by one adding the data type (e.g int, boolean, char, String, float, long, double...)  ►►►►► THIS SECTION IS MANDATORY FOR FUNCTIONS ◄◄◄◄◄
-`pin`: the number of the pin to write to. Allowed data types: int. +
+`pin`: the number of the pin to write to. Allowed data types: int.
+
 `value`: the duty cycle between 0 (always off) and 255 (always on). Allowed data types: int.
 
 


### PR DESCRIPTION
When there were multiple parameters with longer descriptions, the Parameters section ended up looking like a wall of text. Separating each parameter with a blank line makes it easier to read and faster to find the information you're searching for.

This format is also easier for the collaborators to work with because they don't need to remember to add the ` +` at the end of the line. There are currently several reference pages where that was forgotten.

This is a proposal to change the official reference style guide. If accepted, I will update the formatting of all reference pages accordingly.

I had also considered formatting the parameters section as a list. That looks quite nice also, but in the end I decided I slightly preferred the blank lines.

Example of the previous formatting being problematic:
https://www.arduino.cc/reference/en/language/functions/external-interrupts/attachinterrupt#_parameters

Before:
![before](https://user-images.githubusercontent.com/8572152/52330778-2184ab80-29ab-11e9-9730-c4345afa047b.png)

After:
![after](https://user-images.githubusercontent.com/8572152/52330787-28132300-29ab-11e9-85ad-fde310e15f6e.png)