### PR TITLE
Establish a standard for the use of blank lines to separate sections

### DIFF
--- a/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Single_Entity.adoc
+++ b/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Single_Entity.adoc
@@ -12,8 +12,6 @@ subCategories: [ "Subcategory Name" ]
 
 
 
-
-
 // PAGE TITLE
 = title
 
@@ -56,7 +54,6 @@ Nothing
 
 
 
-
 // HOW TO USE SECTION STARTS
 [#howtouse]
 --
@@ -65,7 +62,6 @@ Nothing
 === Example Code
 // Describe what the example code is all about and add relevant code   ►►►►► THIS SECTION IS MANDATORY ◄◄◄◄◄
 Sets the output to the LED proportional to the value read from the potentiometer.
-
 
 [source,arduino]
 // Add relevant code that exemplify the use of the Reference term,
@@ -102,6 +98,7 @@ image::http://arduino.cc/en/uploads/Main/ArduinoUno_R3_Front_450px.jpg[caption="
 // HOW TO USE SECTION ENDS
 
 
+
 // SEE ALSO SECTION
 [#see_also]
 --
@@ -111,7 +108,6 @@ image::http://arduino.cc/en/uploads/Main/ArduinoUno_R3_Front_450px.jpg[caption="
 // Link relevant content by category, such as other Reference terms (please add the tag #LANGUAGE#), 
 // definitions: (please add the tag #DEFINITION#), and examples of Projects and Tutorials
 // examples: (please add the tag #EXAMPLE#)
-
 
 [role="language"]
 // Whenever you want to link to another Reference term, or more in general to a relative link,
@@ -133,4 +129,3 @@ image::http://arduino.cc/en/uploads/Main/ArduinoUno_R3_Front_450px.jpg[caption="
 
 --
 // SEE ALSO SECTION ENDS
-


### PR DESCRIPTION
Blank lines were used inconsistently and unnecessarily in the reference example. I have attempted to decipher the intended spacing standard and apply this across the document.

This proposal establishes an official style. If accepted, I will apply it across all the reference pages, where this sort of inconsistency is widespread.