### PR TITLE
Improve sizeof example code

### DIFF
--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -66,12 +66,15 @@ void loop() {
 
 [float]
 === Notes and Warnings
-Note that `sizeof` returns the total number of bytes. So for larger variable types such as ints, the for loop would look something like this. 
+Note that `sizeof` returns the total number of bytes. So for arrays of larger variable types such as ints, the for loop would look something like this. 
 
 [source,arduino]
 ----
-for (i = 0; i < (sizeof(myInts)/sizeof(myInts[0])); i++) {
-  // do something with myInts[i]
+int myValues[] = {123, 456, 789};
+
+// this for loop works correctly with an array of any type or size
+for (i = 0; i < (sizeof(myValues)/sizeof(myValues[0])); i++) {
+  // do something with myValues[i]
 }
 ----
 


### PR DESCRIPTION
This improves the example code that demonstrates how to use sizeof to determine the number of elements in an array of any type.
- In the description, specify that we're talking about arrays, just to be absolutely clear.
- Define the array in the example code.
- Add an explanatory comment to the for loop

Originally proposed at https://github.com/arduino/reference-pt/pull/222#issuecomment-461949431