### PR TITLE
Fixed incorrect spelling of "until" in blockComment.adoc.

### DIFF
--- a/Language/Structure/Further Syntax/blockComment.adoc
+++ b/Language/Structure/Further Syntax/blockComment.adoc
@@ -21,7 +21,7 @@ subCategories: [ "Further Syntax" ]
 *Comments* are lines in the program that are used to inform yourself or others about the way the program works. They are ignored by the compiler, and not exported to the processor, so they don't take up any space in the microcontroller's flash memory. Comments' only purpose is to help you understand (or remember), or to inform others about how your program works.
 [%hardbreaks]
 
-The beginning of a *block comment* or a *multi-line comment* is marked by the symbol `/\*` and the symbol `*/` marks its end. This type of a comment is called so as this can extend over more than one line; once the compiler reads the `/\*` it ignores whatever follows unitl it enounters a `*/`.
+The beginning of a *block comment* or a *multi-line comment* is marked by the symbol `/\*` and the symbol `*/` marks its end. This type of a comment is called so as this can extend over more than one line; once the compiler reads the `/\*` it ignores whatever follows until it enounters a `*/`.
 
 // NOTE TO THE EDITOR: The '\' before the '*' in certain places are to escape the '*' from making the text bolder.
 // In places were '\' is not used before '*', it is not actually required.


### PR DESCRIPTION
@robsoncouto: Just a small spelling issue.