### PR TITLE
Clarify documentation in attach/detachInterrupt syntax section

### DIFF
--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -59,7 +59,7 @@ For more information on interrupts, see http://gammon.com.au/interrupts[Nick Gam
 === Syntax
 `attachInterrupt(digitalPinToInterrupt(pin), ISR, mode);` (recommended) +
 `attachInterrupt(interrupt, ISR, mode);` (not recommended) +
-`attachInterrupt(pin, ISR, mode);` (Not recommended. Arduino SAMD Boards, Uno WiFi Rev2, Due, 101 only)
+`attachInterrupt(pin, ISR, mode);` (Not recommended. Additionally, this syntax only works on Arduino SAMD Boards, Uno WiFi Rev2, Due, and 101.)
 
 
 [float]

--- a/Language/Functions/External Interrupts/detachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/detachInterrupt.adoc
@@ -25,7 +25,7 @@ Turns off the given interrupt.
 === Syntax
 `detachInterrupt(digitalPinToInterrupt(pin))` (recommended) +
 `detachInterrupt(interrupt)` (not recommended) +
-`detachInterrupt(pin)` (Not recommended. Arduino SAMD Boards, Uno WiFi Rev2, Due, 101 only)
+`detachInterrupt(pin)` (Not recommended. Additionally, this syntax only works on Arduino SAMD Boards, Uno WiFi Rev2, Due, and 101.)
 
 [float]
 === Parameters


### PR DESCRIPTION
Feedback was recieved that it wasn't clear whether the second sentence of the attachInterrupt(pin, ISR, mode) syntax description was related to the first sentence (i.e. is the syntax not recommended for Arduino SAMD Boards, Uno WiFi Rev2, Due, 101 only and the syntax is recommended for any other board type?).

As the notes for the syntax section grow longer, it makes me think that the standard formatting of this section is not ideal. This is a similar situation to what I've already reported for the Parameters section (https://github.com/arduino/reference-en/pull/533), so it would make sense to apply whichever updated formatting standard that's decided on for the Parameters section to the Syntax section as well.

---
Originally reported at http://forum.arduino.cc/index.php?topic=598501.msg4064897#msg4064897