### PR TITLE
Declare counter variable in for statements

### DIFF
--- a/Language/Structure/Control Structure/break.adoc
+++ b/Language/Structure/Control Structure/break.adoc
@@ -36,7 +36,7 @@ In the following code, the control exits the `for` loop when the sensor value ex
 [source,arduino]
 ----
 int threshold = 40;
-for (x = 0; x < 255; x ++) {
+for (int x = 0; x < 255; x ++) {
   analogWrite(PWMpin, x);
   sens = analogRead(sensorPin);
   if (sens > threshold) {     // bail out on sensor detect

--- a/Language/Structure/Control Structure/continue.adoc
+++ b/Language/Structure/Control Structure/continue.adoc
@@ -36,7 +36,7 @@ The `continue` statement skips the rest of the current iteration of a loop (link
 The following code writes the value of 0 to 255 to the `PWMpin`, but skips the values in the range of 41 to 119.
 [source,arduino]
 ----
-for (x = 0; x <= 255; x ++) {
+for (int x = 0; x <= 255; x ++) {
   if (x > 40 && x < 120) {  // create jump in values
     continue;
   }

--- a/Language/Variables/Data Types/array.adoc
+++ b/Language/Variables/Data Types/array.adoc
@@ -67,8 +67,7 @@ Arrays are often manipulated inside for loops, where the loop counter is used as
 
 [source,arduino]
 ----
-int i;
-for (i = 0; i < 5; i = i + 1) {
+for (byte i = 0; i < 5; i = i + 1) {
   Serial.println(myPins[i]);
 }
 ----

--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -71,7 +71,6 @@ const PROGMEM  uint16_t charSet[]  = { 65000, 32796, 16843, 10, 11234};
 const char signMessage[] PROGMEM  = {"I AM PREDATOR,  UNSEEN COMBATANT. CREATED BY THE UNITED STATES DEPART"};
 
 unsigned int displayInt;
-int k;  // counter variable
 char myChar;
 
 
@@ -81,14 +80,14 @@ void setup() {
 
   // put your setup code here, to run once:
   // read back a 2-byte int
-  for (k = 0; k < 5; k++) {
+  for (byte k = 0; k < 5; k++) {
     displayInt = pgm_read_word_near(charSet + k);
     Serial.println(displayInt);
   }
   Serial.println();
 
   // read back a char
-  for (k = 0; k < strlen_P(signMessage); k++) {
+  for (byte k = 0; k < strlen_P(signMessage); k++) {
     myChar =  pgm_read_byte_near(signMessage + k);
     Serial.print(myChar);
   }

--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -46,14 +46,13 @@ This program prints out a text string one character at a time. Try changing the 
 [source,arduino]
 ----
 char myStr[] = "this is a test";
-int i;
 
 void setup() {
   Serial.begin(9600);
 }
 
 void loop() {
-  for (i = 0; i < sizeof(myStr) - 1; i++) {
+  for (byte i = 0; i < sizeof(myStr) - 1; i++) {
     Serial.print(i, DEC);
     Serial.print(" = ");
     Serial.write(myStr[i]);
@@ -73,7 +72,7 @@ Note that `sizeof` returns the total number of bytes. So for arrays of larger va
 int myValues[] = {123, 456, 789};
 
 // this for loop works correctly with an array of any type or size
-for (i = 0; i < (sizeof(myValues) / sizeof(myValues[0])); i++) {
+for (byte i = 0; i < (sizeof(myValues) / sizeof(myValues[0])); i++) {
   // do something with myValues[i]
 }
 ----


### PR DESCRIPTION
Declaring the counter variable outside the for statement is done very rarely in actual programming, and only when there is a use for that variable outside the scope of the for loop (which is not the case here). I don't see any value in declaring the variable outside the statement in the example code, as it only teaches bad programming without providing any benefit. In some cases, the example code snippets didn't even contain a declaration and so would not compile if copied into a sketch.