### PR TITLE
Fix inconsistent formatting of See also links

### DIFF
--- a/Language/Structure/Control Structure/while.adoc
+++ b/Language/Structure/Control Structure/while.adoc
@@ -67,7 +67,7 @@ while (var < 200) {
 [role="language"]
 
 [role="example"]
-* #EXAMPLE#	https://arduino.cc/en/Tutorial/WhileLoop[While Loop Tutorial^]
+* #EXAMPLE# https://arduino.cc/en/Tutorial/WhileLoop[While Loop Tutorial^]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Structure/Further Syntax/define.adoc
+++ b/Language/Structure/Further Syntax/define.adoc
@@ -87,8 +87,8 @@ Similarly, including an equal sign after the #define statement will also generat
 === See also
 
 [role="language"]
-* #LANGUAGE#	link:../../../variables/variable-scope\--qualifiers/const[const]
-* #LANGUAGE#	link:../../../variables/constants/constants[Constants]
+* #LANGUAGE# link:../../../variables/variable-scope\--qualifiers/const[const]
+* #LANGUAGE# link:../../../variables/constants/constants[Constants]
 
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
These links use a tab separator between the tag and link, contrary to the standard established in the [reference sample](https://github.com/arduino/reference-en/blob/master/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Single_Entity.adoc).