### PR TITLE
Use standard format for Syntax, Parameters, and Returns sections

### DIFF
--- a/Language/Functions/Advanced IO/pulseIn.adoc
+++ b/Language/Functions/Advanced IO/pulseIn.adoc
@@ -25,20 +25,20 @@ The timing of this function has been determined empirically and will probably sh
 
 [float]
 === Syntax
-`pulseIn(pin, value)`
-
+`pulseIn(pin, value)` +
 `pulseIn(pin, value, timeout)`
+
 
 [float]
 === Parameters
-`pin`: the number of the pin on which you want to read the pulse. (int)
+`pin`: the number of the pin on which you want to read the pulse. Allowed data types: `int`. +
+`value`: type of pulse to read: either link:../../../variables/constants/constants/[HIGH] or link:../../../variables/constants/constants/[LOW]. Allowed data types: `int`. +
+`timeout` (optional): the number of microseconds to wait for the pulse to start; default is one second. Allowed data types: `unsigned long`.
 
-`value`: type of pulse to read: either link:../../../variables/constants/constants/[HIGH] or link:../../../variables/constants/constants/[LOW]. (int)
 
-`timeout` (optional): the number of microseconds to wait for the pulse to start; default is one second (unsigned long)
 [float]
 === Returns
-the length of the pulse (in microseconds) or 0 if no pulse started before the timeout (unsigned long)
+The length of the pulse (in microseconds) or 0 if no pulse started before the timeout. Data type: `unsigned long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Advanced IO/pulseInLong.adoc
+++ b/Language/Functions/Advanced IO/pulseInLong.adoc
@@ -27,20 +27,20 @@ The timing of this function has been determined empirically and will probably sh
 
 [float]
 === Syntax
-`pulseInLong(pin, value)`
-
+`pulseInLong(pin, value)` +
 `pulseInLong(pin, value, timeout)`
+
 
 [float]
 === Parameters
-`pin`: the number of the pin on which you want to read the pulse. (int)
+`pin`: the number of the pin on which you want to read the pulse. Allowed data types: `int`. +
+`value`: type of pulse to read: either link:../../../variables/constants/constants/[HIGH] or link:../../../variables/constants/constants/[LOW]. Allowed data types: `int`. +
+`timeout` (optional): the number of microseconds to wait for the pulse to start; default is one second. Allowed data types: `unsigned long`.
 
-`value`: type of pulse to read: either link:../../../variables/constants/constants/[HIGH] or link:../../../variables/constants/constants/[LOW]. (int)
 
-`timeout` (optional): the number of microseconds to wait for the pulse to start; default is one second (unsigned long)
 [float]
 === Returns
-the length of the pulse (in microseconds) or 0 if no pulse started before the timeout (unsigned long)
+The length of the pulse (in microseconds) or 0 if no pulse started before the timeout. Data type: `unsigned long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Advanced IO/shiftIn.adoc
+++ b/Language/Functions/Advanced IO/shiftIn.adoc
@@ -32,16 +32,14 @@ Note: this is a software implementation; Arduino also provides an link:https://w
 
 [float]
 === Parameters
-`dataPin`: the pin on which to input each bit (int)
+`dataPin`: the pin on which to input each bit. Allowed data types: `int`. +
+`clockPin`: the pin to toggle to signal a read from *dataPin*. +
+`bitOrder`: which order to shift in the bits; either *MSBFIRST* or *LSBFIRST*. (Most Significant Bit First, or, Least Significant Bit First).
 
-`clockPin`: the pin to toggle to signal a read from *dataPin*
-
-`bitOrder`: which order to shift in the bits; either *MSBFIRST* or *LSBFIRST*.
-(Most Significant Bit First, or, Least Significant Bit First)
 
 [float]
 === Returns
-the value read (byte)
+The value read. Data type: `byte`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Advanced IO/shiftOut.adoc
+++ b/Language/Functions/Advanced IO/shiftOut.adoc
@@ -28,14 +28,11 @@ This is a software implementation; see also the https://www.arduino.cc/en/Refere
 
 [float]
 === Parameters
-`dataPin`: the pin on which to output each bit (int)
+`dataPin`: the pin on which to output each bit. Allowed data types: `int`. +
+`clockPin`: the pin to toggle once the dataPin has been set to the correct value. Allowed data types: `int`. +
+`bitOrder`: which order to shift out the bits; either MSBFIRST or LSBFIRST. (Most Significant Bit First, or, Least Significant Bit First). +
+`value`: the data to shift out. Allowed data types: `byte`.
 
-`clockPin`: the pin to toggle once the dataPin has been set to the correct value (int)
-
-`bitOrder`: which order to shift out the bits; either MSBFIRST or LSBFIRST.
-(Most Significant Bit First, or, Least Significant Bit First)
-
-`value`: the data to shift out. (byte)
 
 [float]
 === Returns

--- a/Language/Functions/Advanced IO/tone.adoc
+++ b/Language/Functions/Advanced IO/tone.adoc
@@ -29,19 +29,16 @@ It is not possible to generate tones lower than 31Hz. For technical details, see
 
 [float]
 === Syntax
-`tone(pin, frequency)`
-
+`tone(pin, frequency)` +
 `tone(pin, frequency, duration)`
-[%hardbreaks]
+
 
 [float]
 === Parameters
-`pin`: the pin on which to generate the tone
+`pin`: the pin on which to generate the tone. +
+`frequency`: the frequency of the tone in hertz. Allowed data types: `unsigned int`. +
+`duration`: the duration of the tone in milliseconds (optional). Allowed data types: `unsigned long`.
 
-`frequency`: the frequency of the tone in hertz - `unsigned int`
-
-`duration`: the duration of the tone in milliseconds (optional) - `unsigned long`
-[%hardbreaks]
 
 [float]
 === Returns

--- a/Language/Functions/Analog IO/analogRead.adoc
+++ b/Language/Functions/Analog IO/analogRead.adoc
@@ -38,17 +38,17 @@ On ATmega based boards (UNO, Nano, Mini, Mega), it takes about 100 microseconds 
 
 [float]
 === Syntax
-
 `analogRead(pin)`
+
 
 [float]
 === Parameters
 `pin`: the name of the analog input pin to read from (A0 to A5 on most boards, A0 to A6 on MKR boards, A0 to A7 on the Mini and Nano, A0 to A15 on the Mega).
 
+
 [float]
 === Returns
-
-The analog reading on the pin (int). Although it is limited to the resolution of the analog to digital converter (0-1023 for 10 bits or 0-4095 for 12 bits).
+The analog reading on the pin. Although it is limited to the resolution of the analog to digital converter (0-1023 for 10 bits or 0-4095 for 12 bits). Data type: `int`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Analog IO/analogReference.adoc
+++ b/Language/Functions/Analog IO/analogReference.adoc
@@ -52,6 +52,7 @@ Arduino SAM Boards (Due)
 === Parameters
 `type`: which type of reference to use (see list of options in the description).
 
+
 [float]
 === Returns
 Nothing

--- a/Language/Functions/Analog IO/analogWrite.adoc
+++ b/Language/Functions/Analog IO/analogWrite.adoc
@@ -33,8 +33,8 @@ The `analogWrite` function has nothing to do with the analog pins or the `analog
 
 [float]
 === Parameters
-`pin`: the pin to write to. Allowed data types: int. +
-`value`: the duty cycle: between 0 (always off) and 255 (always on). Allowed data types: int
+`pin`: the pin to write to. Allowed data types: `int`. +
+`value`: the duty cycle: between 0 (always off) and 255 (always on). Allowed data types: `int`.
 
 
 [float]

--- a/Language/Functions/Bits and Bytes/bit.adoc
+++ b/Language/Functions/Bits and Bytes/bit.adoc
@@ -30,6 +30,7 @@ Computes the value of the specified bit (bit 0 is 1, bit 1 is 2, bit 2 is 4, etc
 === Parameters
 `n`: the bit whose value to compute
 
+
 [float]
 === Returns
 The value of the bit.

--- a/Language/Functions/Bits and Bytes/bitClear.adoc
+++ b/Language/Functions/Bits and Bytes/bitClear.adoc
@@ -28,9 +28,9 @@ Clears (writes a 0 to) a bit of a numeric variable.
 
 [float]
 === Parameters
-`x`: the numeric variable whose bit to clear
+`x`: the numeric variable whose bit to clear. +
+`n`: which bit to clear, starting at 0 for the least-significant (rightmost) bit.
 
-`n`: which bit to clear, starting at 0 for the least-significant (rightmost) bit
 
 [float]
 === Returns

--- a/Language/Functions/Bits and Bytes/bitRead.adoc
+++ b/Language/Functions/Bits and Bytes/bitRead.adoc
@@ -28,14 +28,13 @@ Reads a bit of a number.
 
 [float]
 === Parameters
-`x`: the number from which to read
-
-`n`: which bit to read, starting at 0 for the least-significant (rightmost) bit
+`x`: the number from which to read. +
+`n`: which bit to read, starting at 0 for the least-significant (rightmost) bit.
 
 
 [float]
 === Returns
-the value of the bit (0 or 1).
+The value of the bit (0 or 1).
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Bits and Bytes/bitSet.adoc
+++ b/Language/Functions/Bits and Bytes/bitSet.adoc
@@ -28,9 +28,9 @@ Sets (writes a 1 to) a bit of a numeric variable.
 
 [float]
 === Parameters
-`x`: the numeric variable whose bit to set
+`x`: the numeric variable whose bit to set. +
+`n`: which bit to set, starting at 0 for the least-significant (rightmost) bit.
 
-`n`: which bit to set, starting at 0 for the least-significant (rightmost) bit
 
 [float]
 === Returns

--- a/Language/Functions/Bits and Bytes/bitWrite.adoc
+++ b/Language/Functions/Bits and Bytes/bitWrite.adoc
@@ -28,11 +28,10 @@ Writes a bit of a numeric variable.
 
 [float]
 === Parameters
-`x`: the numeric variable to which to write
+`x`: the numeric variable to which to write. +
+`n`: which bit of the number to write, starting at 0 for the least-significant (rightmost) bit. +
+`b`: the value to write to the bit (0 or 1).
 
-`n`: which bit of the number to write, starting at 0 for the least-significant (rightmost) bit
-
-`b`: the value to write to the bit (0 or 1)
 
 [float]
 === Returns

--- a/Language/Functions/Bits and Bytes/highByte.adoc
+++ b/Language/Functions/Bits and Bytes/highByte.adoc
@@ -30,9 +30,10 @@ Extracts the high-order (leftmost) byte of a word (or the second lowest byte of 
 === Parameters
 `x`: a value of any type
 
+
 [float]
 === Returns
-byte
+Data type: `byte`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Bits and Bytes/lowByte.adoc
+++ b/Language/Functions/Bits and Bytes/lowByte.adoc
@@ -30,9 +30,11 @@ Extracts the low-order (rightmost) byte of a variable (e.g. a word).
 === Parameters
 `x`: a value of any type
 
+
 [float]
 === Returns
-byte
+Data type: `byte`.
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Functions/Characters/isAlpha.adoc
+++ b/Language/Functions/Characters/isAlpha.adoc
@@ -23,14 +23,13 @@ Analyse if a char is alpha (that is a letter). Returns true if thisChar contains
 
 [float]
 === Syntax
-[source,arduino]
-----
-isAlpha(thisChar)
-----
+`isAlpha(thisChar)`
+
 
 [float]
 === Parameters
-`thisChar`: variable. *Allowed data types:* char
+`thisChar`: variable. Allowed data types: `char`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Characters/isAlphaNumeric.adoc
+++ b/Language/Functions/Characters/isAlphaNumeric.adoc
@@ -23,14 +23,13 @@ Analyse if a char is alphanumeric (that is a letter or a numbers). Returns true 
 
 [float]
 === Syntax
-[source,arduino]
-----
-isAlphaNumeric(thisChar)
-----
+`isAlphaNumeric(thisChar)`
+
 
 [float]
 === Parameters
-`thisChar`: variable. *Allowed data types:* char
+`thisChar`: variable. Allowed data types: `char`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Characters/isAscii.adoc
+++ b/Language/Functions/Characters/isAscii.adoc
@@ -23,14 +23,13 @@ Analyse if a char is Ascii. Returns true if thisChar contains an Ascii character
 
 [float]
 === Syntax
-[source,arduino]
-----
-isAscii(thisChar)
-----
+`isAscii(thisChar)`
+
 
 [float]
 === Parameters
-`thisChar`: variable. *Allowed data types:* char
+`thisChar`: variable. Allowed data types: `char`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Characters/isControl.adoc
+++ b/Language/Functions/Characters/isControl.adoc
@@ -23,14 +23,13 @@ Analyse if a char is a control character. Returns true if thisChar is a control 
 
 [float]
 === Syntax
-[source,arduino]
-----
-isControl(thisChar)
-----
+`isControl(thisChar)`
+
 
 [float]
 === Parameters
-`thisChar`: variable. *Allowed data types:* char
+`thisChar`: variable. Allowed data types: `char`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Characters/isDigit.adoc
+++ b/Language/Functions/Characters/isDigit.adoc
@@ -23,14 +23,13 @@ Analyse if a char is a digit (that is a number). Returns true if thisChar is a n
 
 [float]
 === Syntax
-[source,arduino]
-----
-isDigit(thisChar)
-----
+`isDigit(thisChar)`
+
 
 [float]
 === Parameters
-`thisChar`: variable. *Allowed data types:* char
+`thisChar`: variable. Allowed data types: `char`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Characters/isGraph.adoc
+++ b/Language/Functions/Characters/isGraph.adoc
@@ -23,14 +23,12 @@ Analyse if a char is printable with some content (space is printable but has no 
 
 [float]
 === Syntax
-[source,arduino]
-----
-isGraph(thisChar)
-----
+`isGraph(thisChar)`
 
 [float]
 === Parameters
-`thisChar`: variable. *Allowed data types:* char
+`thisChar`: variable. Allowed data types: `char`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Characters/isHexadecimalDigit.adoc
+++ b/Language/Functions/Characters/isHexadecimalDigit.adoc
@@ -23,16 +23,13 @@ Analyse if a char is an hexadecimal digit (A-F, 0-9). Returns true if thisChar c
 
 [float]
 === Syntax
-[source,arduino]
-----
+`isHexadecimalDigit(thisChar)`
 
-isHexadecimalDigit(thisChar)
-
-----
 
 [float]
 === Parameters
-`thisChar`: variable. *Allowed data types:* char
+`thisChar`: variable. Allowed data types: `char`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Characters/isLowerCase.adoc
+++ b/Language/Functions/Characters/isLowerCase.adoc
@@ -23,14 +23,13 @@ Analyse if a char is lower case (that is a letter in lower case). Returns true i
 
 [float]
 === Syntax
-[source,arduino]
-----
-isLowerCase(thisChar)
-----
+`isLowerCase(thisChar)`
+
 
 [float]
 === Parameters
-`thisChar`: variable. *Allowed data types:* char
+`thisChar`: variable. Allowed data types: `char`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Characters/isPrintable.adoc
+++ b/Language/Functions/Characters/isPrintable.adoc
@@ -23,14 +23,13 @@ Analyse if a char is printable (that is any character that produces an output, e
 
 [float]
 === Syntax
-[source,arduino]
-----
-isPrintable(thisChar)
-----
+`isPrintable(thisChar)`
+
 
 [float]
 === Parameters
-`thisChar`: variable. *Allowed data types:* char
+`thisChar`: variable. Allowed data types: `char`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Characters/isPunct.adoc
+++ b/Language/Functions/Characters/isPunct.adoc
@@ -23,14 +23,13 @@ Analyse if a char is punctuation (that is a comma, a semicolon, an exlamation ma
 
 [float]
 === Syntax
-[source,arduino]
-----
-isPunct(thisChar)
-----
+`isPunct(thisChar)`
+
 
 [float]
 === Parameters
-`thisChar`: variable. *Allowed data types:* char
+`thisChar`: variable. Allowed data types: `char`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Characters/isSpace.adoc
+++ b/Language/Functions/Characters/isSpace.adoc
@@ -23,14 +23,13 @@ Analyse if a char is the space character. Returns true if thisChar contains the 
 
 [float]
 === Syntax
-[source,arduino]
-----
-isSpace(thisChar)
-----
+`isSpace(thisChar)`
+
 
 [float]
 === Parameters
-`thisChar`: variable. *Allowed data types:* char
+`thisChar`: variable. Allowed data types: `char`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Characters/isUpperCase.adoc
+++ b/Language/Functions/Characters/isUpperCase.adoc
@@ -19,14 +19,13 @@ Analyse if a char is upper case (that is, a letter in upper case). Returns true 
 
 [float]
 === Syntax
-[source,arduino]
-----
-isUpperCase(thisChar)
-----
+`isUpperCase(thisChar)`
+
 
 [float]
 === Parameters
-`thisChar`: variable. *Allowed data types:* char
+`thisChar`: variable. Allowed data types: `char`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Characters/isWhitespace.adoc
+++ b/Language/Functions/Characters/isWhitespace.adoc
@@ -24,13 +24,13 @@ Returns true if thisChar contains a white space.
 
 [float]
 === Syntax
-[source,arduino]
-isWhitespace(thisChar)
+`isWhitespace(thisChar)`
 
 
 [float]
 === Parameters
-`thisChar`: variable. *Allowed data types:* char
+`thisChar`: variable. Allowed data types: `char`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Communication/Serial/available.adoc
+++ b/Language/Functions/Communication/Serial/available.adoc
@@ -21,13 +21,16 @@ Get the number of bytes (characters) available for reading from the serial port.
 === Syntax
 `_Serial_.available()`
 
+
 [float]
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page].
 
+
 [float]
 === Returns
-The number of bytes available to read .
+The number of bytes available to read.
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Functions/Communication/Serial/availableForWrite.adoc
+++ b/Language/Functions/Communication/Serial/availableForWrite.adoc
@@ -27,9 +27,11 @@ Get the number of bytes (characters) available for writing in the serial buffer 
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page].
 
+
 [float]
 === Returns
 The number of bytes available to write.
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Functions/Communication/Serial/begin.adoc
+++ b/Language/Functions/Communication/Serial/begin.adoc
@@ -26,15 +26,11 @@ An optional second argument configures the data, parity, and stop bits. The defa
 `_Serial_.begin(speed, config)`
 
 
-
 [float]
 === Parameters
-`_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page].
-
-`speed`: in bits per second (baud) - `long`
-
-`config`: sets data, parity, and stop bits. Valid values are
-
+`_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
+`speed`: in bits per second (baud). Allowed data types: `long`. +
+`config`: sets data, parity, and stop bits. Valid values are: +
 `SERIAL_5N1` +
 `SERIAL_6N1` +
 `SERIAL_7N1` +
@@ -58,7 +54,8 @@ An optional second argument configures the data, parity, and stop bits. The defa
 `SERIAL_5O2` +
 `SERIAL_6O2` +
 `SERIAL_7O2` +
-`SERIAL_8O2` +
+`SERIAL_8O2`
+
 
 [float]
 === Returns

--- a/Language/Functions/Communication/Serial/end.adoc
+++ b/Language/Functions/Communication/Serial/end.adoc
@@ -27,6 +27,7 @@ Disables serial communication, allowing the RX and TX pins to be used for genera
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page].
 
+
 [float]
 === Returns
 Nothing

--- a/Language/Functions/Communication/Serial/find.adoc
+++ b/Language/Functions/Communication/Serial/find.adoc
@@ -25,17 +25,17 @@ Serial.find() inherits from the link:../../stream[stream] utility class.
 `_Serial_.find(target)` +
 `_Serial_.find(target, length)`
 
+
 [float]
 === Parameters
-`_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page].
+`_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
+`target`: the string to search for. Allowed data types: `char`. +
+`length`: length of the target. Allowed data types: `size_t`.
 
-`target` : the string to search for (char)
-
-`length` : length of the target (size_t)
 
 [float]
 === Returns
-`bool`
+Data type: `bool`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/findUntil.adoc
+++ b/Language/Functions/Communication/Serial/findUntil.adoc
@@ -30,12 +30,13 @@ The function returns true if the target string is found, false if it times out.
 [float]
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
-`target` : the string to search for (char) +
-`terminal` : the terminal string in the search (char)
+`target`: the string to search for. Allowed data types: `char`. +
+`terminal`: the terminal string in the search. Allowed data types: `char`.
+
 
 [float]
 === Returns
-`bool`
+Data type: `bool`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/flush.adoc
+++ b/Language/Functions/Communication/Serial/flush.adoc
@@ -29,6 +29,7 @@ Waits for the transmission of outgoing serial data to complete. (Prior to Arduin
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page].
 
+
 [float]
 === Returns
 Nothing

--- a/Language/Functions/Communication/Serial/getTimeout.adoc
+++ b/Language/Functions/Communication/Serial/getTimeout.adoc
@@ -24,13 +24,15 @@ title: Serial.getTimeout()
 === Syntax
 `_Serial_.getTimeout()`
 
+
 [float]
 === Parameters
 None
 
+
 [float]
 === Returns
-The timeout value set by `Serial.setTimeout()` (unsigned long)
+The timeout value set by `Serial.setTimeout()`. Data type: `unsigned long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/ifSerial.adoc
+++ b/Language/Functions/Communication/Serial/ifSerial.adoc
@@ -26,13 +26,15 @@ This was introduced in Arduino IDE 1.0.1.
 === Syntax
 `if (Serial)`
 
+
 [float]
 === Parameters
-Nothing
+None
+
 
 [float]
 === Returns
-`bool` : returns true if the specified serial port is available. This will only return false if querying the Leonardo's USB CDC serial connection before it is ready.
+Returns true if the specified serial port is available. This will only return false if querying the Leonardo's USB CDC serial connection before it is ready. Data type: `bool`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/parseFloat.adoc
+++ b/Language/Functions/Communication/Serial/parseFloat.adoc
@@ -38,9 +38,10 @@ title: Serial.parseFloat()
 
 `ignore`: used to skip the indicated char in the search. Used for example to skip thousands divider. Allowed data types: `char`
 
+
 [float]
 === Returns
-`float`
+Data type: `float`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/parseInt.adoc
+++ b/Language/Functions/Communication/Serial/parseInt.adoc
@@ -44,9 +44,10 @@ In particular:
 
 `ignore`: used to skip the indicated char in the search. Used for example to skip thousands divider. Allowed data types: `char`
 
+
 [float]
 === Returns
-`long` : the next valid integer
+The next valid integer. Data type: `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/peek.adoc
+++ b/Language/Functions/Communication/Serial/peek.adoc
@@ -29,9 +29,10 @@ Returns the next byte (character) of incoming serial data without removing it fr
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page].
 
+
 [float]
 === Returns
-The first byte of incoming serial data available (or -1 if no data is available) - `int`
+The first byte of incoming serial data available (or -1 if no data is available). Data type: `int`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/print.adoc
+++ b/Language/Functions/Communication/Serial/print.adoc
@@ -49,11 +49,12 @@ To send data without conversion to its representation as characters, use link:..
 [float]
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
-`val`: the value to print - any data type
+`val`: the value to print. Allowed data types: any data type.
+
 
 [float]
 === Returns
-`size_t`: `print()` returns the number of bytes written, though reading that number is optional.
+`print()` returns the number of bytes written, though reading that number is optional. Data type: `size_t`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/println.adoc
+++ b/Language/Functions/Communication/Serial/println.adoc
@@ -26,15 +26,15 @@ Prints data to the serial port as human-readable ASCII text followed by a carria
 
 [float]
 === Parameters
-`_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page].
+`_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
+`val`: the value to print. Allowed data types: any data type. +
+`format`: specifies the number base (for integral data types) or number of decimal places (for floating point types).
 
-`val`: the value to print - any data type
-
-`format`: specifies the number base (for integral data types) or number of decimal places (for floating point types)
 
 [float]
 === Returns
-`size_t`: `println()` returns the number of bytes written, though reading that number is optional
+`println()` returns the number of bytes written, though reading that number is optional. Data type: `size_t`.
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Functions/Communication/Serial/read.adoc
+++ b/Language/Functions/Communication/Serial/read.adoc
@@ -29,9 +29,10 @@ Reads incoming serial data.
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page].
 
+
 [float]
 === Returns
-The first byte of incoming serial data available (or -1 if no data is available) - `int`.
+The first byte of incoming serial data available (or -1 if no data is available). Data type: `int`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/readBytes.adoc
+++ b/Language/Functions/Communication/Serial/readBytes.adoc
@@ -29,15 +29,14 @@ title: Serial.readBytes()
 
 [float]
 === Parameters
-`_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page].
+`_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
+`buffer`: the buffer to store the bytes in. Allowed data types: or array of `char` or `byte`s. +
+`length`: the number of bytes to read. Allowed data types: `int`.
 
-`buffer`: the buffer to store the bytes in (`char[]` or `byte[]`)
-
-`length` : the number of bytes to read (`int`)
 
 [float]
 === Returns
-The number of bytes placed in the buffer (`size_t`)
+The number of bytes placed in the buffer. Data type: `size_t`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/readBytesUntil.adoc
+++ b/Language/Functions/Communication/Serial/readBytesUntil.adoc
@@ -29,17 +29,15 @@ Serial.readBytesUntil() reads characters from the serial buffer into an array. T
 
 [float]
 === Parameters
-`_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page].
+`_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
+`character`: the character to search for. Allowed data types: `char`. +
+`buffer`: the buffer to store the bytes in. Allowed data types: array of `char` or `byte`s. +
+`length`: the number of bytes to read. Allowed data types: `int`.
 
-`character` : the character to search for (`char`)
-
-`buffer`: the buffer to store the bytes in (`char[]` or `byte[]`)
-
-`length` : the number of bytes to read (`int`)
 
 [float]
 === Returns
-`size_t`
+Data type: `size_t`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/readString.adoc
+++ b/Language/Functions/Communication/Serial/readString.adoc
@@ -29,9 +29,10 @@ title: Serial.readString()
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page].
 
+
 [float]
 === Returns
-A String read from the serial buffer
+A `String` read from the serial buffer
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/readStringUntil.adoc
+++ b/Language/Functions/Communication/Serial/readStringUntil.adoc
@@ -28,11 +28,12 @@ title: Serial.readStringUntil()
 [float]
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
-`terminator` : the character to search for (`char`)
+`terminator`: the character to search for. Allowed data types: `char`.
+
 
 [float]
 === Returns
-The entire String read from the serial buffer, up to the terminator character
+The entire `String` read from the serial buffer, up to the terminator character
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -43,9 +43,11 @@ void serialEvent3() {
 }
 ----
 
+
 [float]
 === Parameters
 `statements`: any valid statements
+
 
 [float]
 === Returns

--- a/Language/Functions/Communication/Serial/setTimeout.adoc
+++ b/Language/Functions/Communication/Serial/setTimeout.adoc
@@ -24,10 +24,12 @@ title: Serial.setTimeout()
 === Syntax
 `_Serial_.setTimeout(time)`
 
+
 [float]
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
-`time` : timeout duration in milliseconds (`long`).
+`time`: timeout duration in milliseconds. Allowed data types: `long`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Communication/Serial/write.adoc
+++ b/Language/Functions/Communication/Serial/write.adoc
@@ -24,21 +24,16 @@ Writes binary data to the serial port. This data is sent as a byte or series of 
 
 [float]
 === Parameters
-`_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page].
+`_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
+`val`: a value to send as a single byte. +
+`str`: a string to send as a series of bytes. +
+`buf`: an array to send as a series of bytes. +
+`len`: the number of bytes to be sent from the array.
 
-`val`: a value to send as a single byte
-
-`str`: a string to send as a series of bytes
-
-`buf`: an array to send as a series of bytes
-
-`len`: the number of bytes to be sent from the array
 
 [float]
 === Returns
-`size_t`
-
-`write()` will return the number of bytes written, though reading that number is optional
+`write()` will return the number of bytes written, though reading that number is optional. Data type: `size_t`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamAvailable.adoc
+++ b/Language/Functions/Communication/Stream/streamAvailable.adoc
@@ -26,11 +26,12 @@ This function is part of the Stream class, and can be called by any class that i
 
 [float]
 === Parameters
-`stream` : an instance of a class that inherits from Stream.
+`stream`: an instance of a class that inherits from Stream.
+
 
 [float]
 === Returns
-`int` : the number of bytes available to read
+The number of bytes available to read. Data type: `int`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamFind.adoc
+++ b/Language/Functions/Communication/Stream/streamFind.adoc
@@ -28,15 +28,14 @@ This function is part of the Stream class, and can be called by any class that i
 
 [float]
 === Parameters
-`stream` : an instance of a class that inherits from Stream.
+`stream`: an instance of a class that inherits from Stream. +
+`target`: the string to search for. Allowed data types: `char`. +
+`length`: length of the target. Allowed data types: `size_t`.
 
-`target` : the string to search for (`char`)
-
-`length` : length of the target (`size_t`)
 
 [float]
 === Returns
-`bool`
+Data type: `bool`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamFindUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamFindUntil.adoc
@@ -29,15 +29,14 @@ This function is part of the Stream class, and can be called by any class that i
 
 [float]
 === Parameters
-`stream` : an instance of a class that inherits from Stream
+`stream`: an instance of a class that inherits from Stream. +
+`target`: the string to search for. Allowed data types: `char`. +
+`terminal`: the terminal string in the search. Allowed data types: `char`.
 
-`target` : the string to search for (char)
-
-`terminal` : the terminal string in the search (char)
 
 [float]
 === Returns
-`bool`
+Data type: `bool`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamFlush.adoc
+++ b/Language/Functions/Communication/Stream/streamFlush.adoc
@@ -27,7 +27,8 @@ This function is part of the Stream class, and can be called by any class that i
 
 [float]
 === Parameters
-`stream` : an instance of a class that inherits from Stream.
+`stream`: an instance of a class that inherits from Stream.
+
 
 [float]
 === Returns

--- a/Language/Functions/Communication/Stream/streamGetTimeout.adoc
+++ b/Language/Functions/Communication/Stream/streamGetTimeout.adoc
@@ -27,9 +27,10 @@ title: Stream.getTimeout()
 === Parameters
 None
 
+
 [float]
 === Returns
-The timeout value set by `stream.setTimeout()` (unsigned long)
+The timeout value set by `stream.setTimeout()`. Data type: `unsigned long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamParseFloat.adoc
+++ b/Language/Functions/Communication/Stream/streamParseFloat.adoc
@@ -38,9 +38,10 @@ This function is part of the Stream class, and can be called by any class that i
 
 `ignore`: used to skip the indicated char in the search. Used for example to skip thousands divider. Allowed data types: `char`
 
+
 [float]
 === Returns
-`float`
+Data type: `float`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamParseInt.adoc
+++ b/Language/Functions/Communication/Stream/streamParseInt.adoc
@@ -43,9 +43,10 @@ This function is part of the Stream class, and can be called by any class that i
 
 `ignore`: used to skip the indicated char in the search. Used for example to skip thousands divider. Allowed data types: `char`
 
+
 [float]
 === Returns
-`long`
+Data type: `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamPeek.adoc
+++ b/Language/Functions/Communication/Stream/streamPeek.adoc
@@ -27,7 +27,8 @@ This function is part of the Stream class, and can be called by any class that i
 
 [float]
 === Parameters
-`stream` : an instance of a class that inherits from Stream.
+`stream`: an instance of a class that inherits from Stream.
+
 
 [float]
 === Returns

--- a/Language/Functions/Communication/Stream/streamRead.adoc
+++ b/Language/Functions/Communication/Stream/streamRead.adoc
@@ -27,7 +27,8 @@ This function is part of the Stream class, and can be called by any class that i
 
 [float]
 === Parameters
-`stream` : an instance of a class that inherits from Stream.
+`stream`: an instance of a class that inherits from Stream.
+
 
 [float]
 === Returns

--- a/Language/Functions/Communication/Stream/streamReadBytes.adoc
+++ b/Language/Functions/Communication/Stream/streamReadBytes.adoc
@@ -29,15 +29,14 @@ This function is part of the Stream class, and can be called by any class that i
 
 [float]
 === Parameters
-`stream` : an instance of a class that inherits from Stream.
+`stream`: an instance of a class that inherits from Stream. +
+`buffer`: the buffer to store the bytes in. Allowed data types: array of `char` or `byte`s. +
+`length`: the number of bytes to read. Allowed data types: `int`.
 
-`buffer` : the buffer to store the bytes in (`char[]` or `byte[]`)
-
-`length` : the number of bytes to `read(int)`
 
 [float]
 === Returns
-The number of bytes placed in the buffer (`size_t`)
+The number of bytes placed in the buffer. Data type: `size_t`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamReadBytesUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamReadBytesUntil.adoc
@@ -29,13 +29,11 @@ This function is part of the Stream class, and can be called by any class that i
 
 [float]
 === Parameters
-`stream` : an instance of a class that inherits from Stream.
+`stream`: an instance of a class that inherits from Stream. +
+`character`: the character to search for. Allowed data types: `char`. +
+`buffer`: the buffer to store the bytes in. Allowed data types: array of `char` or `byte`s. +
+`length`: the number of bytes to read. Allowed data types: `int`.
 
-`character` : the character to search for (`char`)
-
-`buffer`: the buffer to store the bytes in (`char[]` or `byte[]`)
-
-`length` : the number of bytes to `read(int)`
 
 [float]
 === Returns

--- a/Language/Functions/Communication/Stream/streamReadString.adoc
+++ b/Language/Functions/Communication/Stream/streamReadString.adoc
@@ -27,7 +27,8 @@ This function is part of the Stream class, and can be called by any class that i
 
 [float]
 === Parameters
-`stream` : an instance of a class that inherits from Stream
+`stream`: an instance of a class that inherits from Stream.
+
 
 [float]
 === Returns

--- a/Language/Functions/Communication/Stream/streamReadStringUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamReadStringUntil.adoc
@@ -27,9 +27,9 @@ This function is part of the Stream class, and can be called by any class that i
 
 [float]
 === Parameters
-`stream` : an instance of a class that inherits from Stream.
+`stream`: an instance of a class that inherits from Stream. +
+`terminator`: the character to search for. Allowed data types: `char`.
 
-`terminator` : the character to search for (`char`)
 
 [float]
 === Returns

--- a/Language/Functions/Communication/Stream/streamSetTimeout.adoc
+++ b/Language/Functions/Communication/Stream/streamSetTimeout.adoc
@@ -25,8 +25,9 @@ title: Stream.setTimeout()
 
 [float]
 === Parameters
-`stream` : an instance of a class that inherits from Stream.
-`time` : timeout duration in milliseconds (`long`).
+`stream`: an instance of a class that inherits from Stream. +
+`time`: timeout duration in milliseconds. Allowed data types: `long`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Digital IO/digitalRead.adoc
+++ b/Language/Functions/Digital IO/digitalRead.adoc
@@ -30,6 +30,7 @@ Reads the value from a specified digital pin, either `HIGH` or `LOW`.
 === Parameters
 `pin`: the number of the digital pin you want to read
 
+
 [float]
 === Returns
 `HIGH` or `LOW`

--- a/Language/Functions/Digital IO/digitalWrite.adoc
+++ b/Language/Functions/Digital IO/digitalWrite.adoc
@@ -35,9 +35,9 @@ If you do not set the `pinMode()` to `OUTPUT`, and connect an LED to a pin, when
 
 [float]
 === Parameters
-`pin`: the pin number
+`pin`: the pin number. +
+`value`: `HIGH` or `LOW`.
 
-`value`: `HIGH` or `LOW`
 
 [float]
 === Returns

--- a/Language/Functions/Digital IO/pinMode.adoc
+++ b/Language/Functions/Digital IO/pinMode.adoc
@@ -27,13 +27,12 @@ As of Arduino 1.0.1, it is possible to enable the internal pullup resistors with
 === Syntax
 `pinMode(pin, mode)`
 
+
 [float]
 === Parameters
-`pin`: the number of the pin whose mode you wish to set
+`pin`: the number of the pin whose mode you wish to set. +
+`mode`: `INPUT`, `OUTPUT`, or `INPUT_PULLUP`. See the http://arduino.cc/en/Tutorial/DigitalPins[Digital Pins] page for a more complete description of the functionality.
 
-`mode`: `INPUT`, `OUTPUT`, or `INPUT_PULLUP`. (see the http://arduino.cc/en/Tutorial/DigitalPins[Digital Pins] page for a more complete description of the functionality.)
-
-//Check how to add links
 
 [float]
 === Returns

--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -57,15 +57,15 @@ For more information on interrupts, see http://gammon.com.au/interrupts[Nick Gam
 
 [float]
 === Syntax
-`attachInterrupt(digitalPinToInterrupt(pin), ISR, mode);` (recommended) +
-`attachInterrupt(interrupt, ISR, mode);` (not recommended) +
-`attachInterrupt(pin, ISR, mode);` (Not recommended. Additionally, this syntax only works on Arduino SAMD Boards, Uno WiFi Rev2, Due, and 101.)
+`attachInterrupt(digitalPinToInterrupt(pin), ISR, mode)` (recommended) +
+`attachInterrupt(interrupt, ISR, mode)` (not recommended) +
+`attachInterrupt(pin, ISR, mode)` (Not recommended. Additionally, this syntax only works on Arduino SAMD Boards, Uno WiFi Rev2, Due, and 101.)
 
 
 [float]
 === Parameters
-`interrupt`: the number of the interrupt (`int`) +
-`pin`: the pin number +
+`interrupt`: the number of the interrupt. Allowed data types: `int`. +
+`pin`: the pin number. +
 `ISR`: the ISR to call when the interrupt occurs; this function must take no parameters and return nothing. This function is sometimes referred to as an interrupt service routine. +
 `mode`: defines when the interrupt should be triggered. Four constants are predefined as valid values: +
 
@@ -77,6 +77,7 @@ For more information on interrupts, see http://gammon.com.au/interrupts[Nick Gam
 The Due, Zero and MKR1000 boards allows also: +
 
 * *HIGH* to trigger the interrupt whenever the pin is high.
+
 
 [float]
 === Returns

--- a/Language/Functions/External Interrupts/detachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/detachInterrupt.adoc
@@ -27,11 +27,12 @@ Turns off the given interrupt.
 `detachInterrupt(interrupt)` (not recommended) +
 `detachInterrupt(pin)` (Not recommended. Additionally, this syntax only works on Arduino SAMD Boards, Uno WiFi Rev2, Due, and 101.)
 
+
 [float]
 === Parameters
-`interrupt`: the number of the interrupt to disable (see link:../attachinterrupt[attachInterrupt()] for more details).
-
+`interrupt`: the number of the interrupt to disable (see link:../attachinterrupt[attachInterrupt()] for more details). +
 `pin`: the pin number of the interrupt to disable
+
 
 [float]
 === Returns

--- a/Language/Functions/Interrupts/interrupts.adoc
+++ b/Language/Functions/Interrupts/interrupts.adoc
@@ -28,7 +28,8 @@ Re-enables interrupts (after they've been disabled by link:../nointerrupts[noint
 
 [float]
 === Parameters
-Nothing
+None
+
 
 [float]
 === Returns

--- a/Language/Functions/Interrupts/noInterrupts.adoc
+++ b/Language/Functions/Interrupts/noInterrupts.adoc
@@ -28,7 +28,8 @@ Disables interrupts (you can re-enable them with `interrupts()`). Interrupts all
 
 [float]
 === Parameters
-Nothing
+None
+
 
 [float]
 === Returns

--- a/Language/Functions/Math/abs.adoc
+++ b/Language/Functions/Math/abs.adoc
@@ -25,14 +25,15 @@ Calculates the absolute value of a number.
 === Syntax
 `abs(x)`
 
+
 [float]
 === Parameters
 `x`: the number
 
+
 [float]
 === Returns
-`x`: if x is greater than or equal to 0.
-
+`x`: if x is greater than or equal to 0. +
 `-x`: if x is less than 0.
 
 --

--- a/Language/Functions/Math/constrain.adoc
+++ b/Language/Functions/Math/constrain.adoc
@@ -28,17 +28,16 @@ Constrains a number to be within a range.
 
 [float]
 === Parameters
-`x`: the number to constrain, all data types
-`a`: the lower end of the range, all data types
-`b`: the upper end of the range, all data types
+`x`: the number to constrain Allowed data types: all data types. +
+`a`: the lower end of the range. Allowed data types: all data types. +
+`b`: the upper end of the range. Allowed data types: all data types.
+
 
 [float]
 === Returns
-x: if x is between a and b
-
-a: if x is less than a
-
-b: if x is greater than b
+x: if x is between a and b. +
+a: if x is less than a. +
+b: if x is greater than b.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Math/map.adoc
+++ b/Language/Functions/Math/map.adoc
@@ -42,15 +42,12 @@ The `map()` function uses integer math so will not generate fractions, when the 
 
 [float]
 === Parameters
-`value`: the number to map
+`value`: the number to map. +
+`fromLow`: the lower bound of the value's current range. +
+`fromHigh`: the upper bound of the value's current range. +
+`toLow`: the lower bound of the value's target range. +
+`toHigh`: the upper bound of the value's target range.
 
-`fromLow`: the lower bound of the value's current range
-
-`fromHigh`: the upper bound of the value's current range
-
-`toLow`: the lower bound of the value's target range
-
-`toHigh`: the upper bound of the value's target range
 
 [float]
 === Returns

--- a/Language/Functions/Math/max.adoc
+++ b/Language/Functions/Math/max.adoc
@@ -28,8 +28,9 @@ Calculates the maximum of two numbers.
 
 [float]
 === Parameters
-`x`: the first number, any data type
-`y`: the second number, any data type
+`x`: the first number. Allowed data types: any data type. +
+`y`: the second number. Allowed data types: any data type.
+
 
 [float]
 === Returns

--- a/Language/Functions/Math/min.adoc
+++ b/Language/Functions/Math/min.adoc
@@ -28,9 +28,9 @@ Calculates the minimum of two numbers.
 
 [float]
 === Parameters
-`x`: the first number, any data type
+`x`: the first number. Allowed data types: any data type. +
+`y`: the second number. Allowed data types: any data type.
 
-`y`: the second number, any data type
 
 [float]
 === Returns

--- a/Language/Functions/Math/pow.adoc
+++ b/Language/Functions/Math/pow.adoc
@@ -4,7 +4,12 @@ categories: [ "Functions" ]
 subCategories: [ "Math" ]
 ---
 
+
+
+
+
 = pow(base, exponent)
+
 
 // OVERVIEW SECTION STARTS
 [#overview]
@@ -23,13 +28,13 @@ Calculates the value of a number raised to a power. `pow()` can be used to raise
 
 [float]
 === Parameters
-`base`: the number (`float`)
+`base`: the number. Allowed data types: `float`. +
+`exponent`: the power to which the base is raised. Allowed data types: `float`.
 
-`exponent`: the power to which the base is raised (`float`)
 
 [float]
 === Returns
-The result of the exponentiation (`double`)
+The result of the exponentiation. Data type: `double`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Math/sq.adoc
+++ b/Language/Functions/Math/sq.adoc
@@ -28,11 +28,12 @@ Calculates the square of a number: the number multiplied by itself.
 
 [float]
 === Parameters
-`x`: the number, any data type
+`x`: the number. Allowed data types: any data type.
+
 
 [float]
 === Returns
-The square of the number. (double)
+The square of the number. Data type: `double`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Math/sqrt.adoc
+++ b/Language/Functions/Math/sqrt.adoc
@@ -28,11 +28,12 @@ Calculates the square root of a number.
 
 [float]
 === Parameters
-`x`: the number, any data type
+`x`: the number. Allowed data types: any data type.
+
 
 [float]
 === Returns
-The number's square root. (double)
+The number's square root. Data type: `double`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Random Numbers/random.adoc
+++ b/Language/Functions/Random Numbers/random.adoc
@@ -29,13 +29,13 @@ The random function generates pseudo-random numbers.
 
 [float]
 === Parameters
-`min` - lower bound of the random value, inclusive (optional)
+`min`: lower bound of the random value, inclusive (optional). +
+`max`: upper bound of the random value, exclusive.
 
-`max` - upper bound of the random value, exclusive
 
 [float]
 === Returns
-A random number between min and max-1 (`long`) .
+A random number between min and max-1. Data type: `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Random Numbers/randomSeed.adoc
+++ b/Language/Functions/Random Numbers/randomSeed.adoc
@@ -25,12 +25,15 @@ Conversely, it can occasionally be useful to use pseudo-random sequences that re
 [%hardbreaks]
 
 
-
+[float]
+=== Syntax
+`randomSeed(seed)`
 
 
 [float]
 === Parameters
-`seed` - number to initialize the pseudo-random sequence (unsigned long).
+`seed`: number to initialize the pseudo-random sequence. Allowed data types: `unsigned long`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Time/delay.adoc
+++ b/Language/Functions/Time/delay.adoc
@@ -28,7 +28,8 @@ Pauses the program for the amount of time (in milliseconds) specified as paramet
 
 [float]
 === Parameters
-`ms`: the number of milliseconds to pause (`unsigned long`)
+`ms`: the number of milliseconds to pause. Allowed data types: `unsigned long`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Time/delayMicroseconds.adoc
+++ b/Language/Functions/Time/delayMicroseconds.adoc
@@ -30,7 +30,8 @@ Currently, the largest value that will produce an accurate delay is 16383. This 
 
 [float]
 === Parameters
-`us`: the number of microseconds to pause (`unsigned int`)
+`us`: the number of microseconds to pause. Allowed data types: `unsigned int`.
+
 
 [float]
 === Returns

--- a/Language/Functions/Time/micros.adoc
+++ b/Language/Functions/Time/micros.adoc
@@ -28,11 +28,12 @@ Returns the number of microseconds since the Arduino board began running the cur
 
 [float]
 === Parameters
-Nothing
+None
+
 
 [float]
 === Returns
-Returns the number of microseconds since the Arduino board began running the current program.(unsigned long)
+Returns the number of microseconds since the Arduino board began running the current program. Data type: `unsigned long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Time/millis.adoc
+++ b/Language/Functions/Time/millis.adoc
@@ -25,9 +25,10 @@ Returns the number of milliseconds passed since the Arduino board began running 
 === Parameters
 None
 
+
 [float]
 === Returns
-Number of milliseconds passed since the program started (unsigned long)
+Number of milliseconds passed since the program started. Data type: `unsigned long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Trigonometry/cos.adoc
+++ b/Language/Functions/Trigonometry/cos.adoc
@@ -28,11 +28,12 @@ Calculates the cosine of an angle (in radians). The result will be between -1 an
 
 [float]
 === Parameters
-`rad`: The angle in Radians (float).
+`rad`: The angle in radians. Allowed data types: `float`.
+
 
 [float]
 === Returns
-The cos of the angle (`double`).
+The cos of the angle. Data type: `double`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Trigonometry/sin.adoc
+++ b/Language/Functions/Trigonometry/sin.adoc
@@ -28,11 +28,12 @@ Calculates the sine of an angle (in radians). The result will be between -1 and 
 
 [float]
 === Parameters
-`rad`: The angle in Radians (`float`).
+`rad`: The angle in radians. Allowed data types: `float`.
+
 
 [float]
 === Returns
-The sine of the angle (`double`).
+The sine of the angle. Data type: `double`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Trigonometry/tan.adoc
+++ b/Language/Functions/Trigonometry/tan.adoc
@@ -28,11 +28,12 @@ Calculates the tangent of an angle (in radians). The result will be between nega
 
 [float]
 === Parameters
-`rad`: The angle in Radians (`float`).
+`rad`: The angle in radians. Allowed data types: `float`.
+
 
 [float]
 === Returns
-The tangent of the angle (`double`).
+The tangent of the angle. Data type: `double`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/USB/Keyboard/keyboardBegin.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardBegin.adoc
@@ -25,7 +25,8 @@ When used with a Leonardo or Due board, `Keyboard.begin()` starts emulating a ke
 
 [float]
 === Parameters
-Nothing
+None
+
 
 [float]
 === Returns

--- a/Language/Functions/USB/Keyboard/keyboardEnd.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardEnd.adoc
@@ -25,7 +25,8 @@ Stops the keyboard emulation to a connected computer. To start keyboard emulatio
 
 [float]
 === Parameters
-Nothing
+None
+
 
 [float]
 === Returns

--- a/Language/Functions/USB/Keyboard/keyboardPress.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPress.adoc
@@ -22,16 +22,17 @@ It is necessary to call link:../keyboardbegin[Keyboard.begin()] before using `pr
 
 [float]
 === Syntax
-`Keyboard.press()`
+`Keyboard.press(key)`
 
 
 [float]
 === Parameters
-`char` : the key to press
+`key`: the key to press. Allowed data types: `char`.
+
 
 [float]
 === Returns
-`size_t` : number of key presses sent.
+Number of key presses sent. Data type: `size_t`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/USB/Keyboard/keyboardPrint.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPrint.adoc
@@ -25,13 +25,16 @@ Sends a keystroke to a connected computer.
 `Keyboard.print(character)` +
 `Keyboard.print(characters)`
 
+
 [float]
 === Parameters
-`character` : a char or int to be sent to the computer as a keystroke characters : a string to be sent to the computer as a keystroke.
+`character`: a char or int to be sent to the computer as a keystroke. +
+`characters`: a string to be sent to the computer as a keystroke.
+
 
 [float]
 === Returns
-`size_t` : number of bytes sent.
+Number of bytes sent. Data type: `size_t`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
@@ -26,15 +26,16 @@ Sends a keystroke to a connected computer, followed by a newline and carriage re
 `Keyboard.println(character)`+
 `Keyboard.println(characters)`
 
+
 [float]
 === Parameters
-`character` : a char or int to be sent to the computer as a keystroke, followed by newline and carriage return.
+`character`: a char or int to be sent to the computer as a keystroke, followed by newline and carriage return. +
+`characters`: a string to be sent to the computer as a keystroke, followed by a newline and carriage return.
 
-`characters` : a string to be sent to the computer as a keystroke, followed by a newline and carriage return.
 
 [float]
 === Returns
-`size_t` : number of bytes sent
+Number of bytes sent. Data type: `size_t`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/USB/Keyboard/keyboardRelease.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardRelease.adoc
@@ -25,11 +25,12 @@ Lets go of the specified key. See link:../keyboardpress[Keyboard.press()] for mo
 
 [float]
 === Parameters
-`key` : the key to release. `char`
+`key`: the key to release. Allowed data types: `char`.
+
 
 [float]
 === Returns
-`size_t` : the number of keys released
+The number of keys released. Data type: `size_t`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/USB/Keyboard/keyboardReleaseAll.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardReleaseAll.adoc
@@ -25,7 +25,8 @@ Lets go of all keys currently pressed. See link:../keyboardpress[Keyboard.press(
 
 [float]
 === Parameters
-Nothing
+None
+
 
 [float]
 === Returns

--- a/Language/Functions/USB/Keyboard/keyboardWrite.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardWrite.adoc
@@ -29,7 +29,7 @@ For a complete list of ASCII characters, see http://www.asciitable.com/[ASCIITab
 
 [float]
 === Parameters
-`character` : a char or int to be sent to the computer. Can be sent in any notation that's acceptable for a char. For example, all of the below are acceptable and send the same value, 65 or ASCII A:
+`character`: a char or int to be sent to the computer. Can be sent in any notation that's acceptable for a char. For example, all of the below are acceptable and send the same value, 65 or ASCII A:
 [source,arduino]
 ----
 Keyboard.write(65);         // sends ASCII value 65, or A
@@ -38,9 +38,10 @@ Keyboard.write(0x41);       // same thing in hexadecimal
 Keyboard.write(0b01000001); // same thing in binary (weird choice, but it works)
 ----
 
+
 [float]
 === Returns
-`size_t` : number of bytes sent.
+Number of bytes sent. Data type: `size_t`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/USB/Mouse/mouseBegin.adoc
+++ b/Language/Functions/USB/Mouse/mouseBegin.adoc
@@ -26,7 +26,8 @@ Begins emulating the mouse connected to a computer. `begin()` must be called bef
 
 [float]
 === Parameters
-Nothing
+None
+
 
 [float]
 === Returns

--- a/Language/Functions/USB/Mouse/mouseClick.adoc
+++ b/Language/Functions/USB/Mouse/mouseClick.adoc
@@ -28,11 +28,12 @@ Sends a momentary click to the computer at the location of the cursor. This is t
 
 [float]
 === Parameters
-`button`: which mouse button to press - `char`
+`button`: which mouse button to press. Allowed data types: `char`.
 
 * `MOUSE_LEFT` (default)
 * `MOUSE_RIGHT`
 * `MOUSE_MIDDLE`
+
 
 [float]
 === Returns

--- a/Language/Functions/USB/Mouse/mouseEnd.adoc
+++ b/Language/Functions/USB/Mouse/mouseEnd.adoc
@@ -25,7 +25,8 @@ Stops emulating the mouse connected to a computer. To start control, use link:..
 
 [float]
 === Parameters
-Nothing
+None
+
 
 [float]
 === Returns

--- a/Language/Functions/USB/Mouse/mouseIsPressed.adoc
+++ b/Language/Functions/USB/Mouse/mouseIsPressed.adoc
@@ -27,17 +27,16 @@ Checks the current status of all mouse buttons, and reports if any are pressed o
 === Parameters
 When there is no value passed, it checks the status of the left mouse button.
 
-`button`: which mouse button to check - `char`
+`button`: which mouse button to check. Allowed data types: `char`.
 
 * `MOUSE_LEFT (default)`
-
 * `MOUSE_RIGHT`
-
 * `MOUSE_MIDDLE`
+
 
 [float]
 === Returns
-`bool` : reports whether a button is pressed or not.
+Reports whether a button is pressed or not. Data type: `bool`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/USB/Mouse/mouseMove.adoc
+++ b/Language/Functions/USB/Mouse/mouseMove.adoc
@@ -20,16 +20,16 @@ Moves the cursor on a connected computer. The motion onscreen is always relative
 
 [float]
 === Syntax
-`Mouse.move(xVal, yVal, wheel);`
+`Mouse.move(xVal, yVal, wheel)`
 
 
 [float]
 === Parameters
-`xVal`: amount to move along the x-axis - `signed char`
+`xVal`: amount to move along the x-axis. Allowed data types: `signed char`. +
+`yVal`: amount to move along the y-axis. Allowed data types: `signed char`. +
+`wheel`: amount to move scroll wheel. Allowed data types: `signed char`.
 
-`yVal`: amount to move along the y-axis - `signed char`
 
-`wheel`: amount to move scroll wheel - `signed char`
 [float]
 === Returns
 Nothing

--- a/Language/Functions/USB/Mouse/mousePress.adoc
+++ b/Language/Functions/USB/Mouse/mousePress.adoc
@@ -30,13 +30,12 @@ Before using `Mouse.press()`, you need to start communication with link:../mouse
 
 [float]
 === Parameters
-`button`: which mouse button to press - `char`
+`button`: which mouse button to press. Allowed data types: `char`.
 
 * `MOUSE_LEFT (default)`
-
 * `MOUSE_RIGHT`
-
 * `MOUSE_MIDDLE`
+
 
 [float]
 === Returns

--- a/Language/Functions/USB/Mouse/mouseRelease.adoc
+++ b/Language/Functions/USB/Mouse/mouseRelease.adoc
@@ -20,18 +20,18 @@ Sends a message that a previously pressed button (invoked through link:../mousep
 
 [float]
 === Syntax
-`Mouse.release();` +
-`Mouse.release(button);`
+`Mouse.release()` +
+`Mouse.release(button)`
+
 
 [float]
 === Parameters
-`button`: which mouse button to press - char
+`button`: which mouse button to press. Allowed data types: `char`.
 
 * `MOUSE_LEFT` (default)
-
 * `MOUSE_RIGHT`
-
 * `MOUSE_MIDDLE`
+
 
 [float]
 === Returns

--- a/Language/Functions/Zero, Due, MKR Family/analogReadResolution.adoc
+++ b/Language/Functions/Zero, Due, MKR Family/analogReadResolution.adoc
@@ -33,6 +33,7 @@ The *Due, Zero and MKR Family* boards have 12-bit ADC capabilities that can be a
 === Parameters
 `bits`: determines the resolution (in bits) of the value returned by the `analogRead()` function. You can set this between 1 and 32. You can set resolutions higher than 12 but values returned by `analogRead()` will suffer approximation. See the note below for details.
 
+
 [float]
 === Returns
 Nothing

--- a/Language/Functions/Zero, Due, MKR Family/analogWriteResolution.adoc
+++ b/Language/Functions/Zero, Due, MKR Family/analogWriteResolution.adoc
@@ -54,6 +54,7 @@ By setting the write resolution to 12 bits, you can use `analogWrite()` with val
 === Parameters
 `bits`: determines the resolution (in bits) of the values used in the `analogWrite()` function. The value can range from 1 to 32. If you choose a resolution higher or lower than your board's hardware capabilities, the value used in `analogWrite()` will be either truncated if it's too high or padded with zeros if it's too low. See the note below for details.
 
+
 [float]
 === Returns
 Nothing

--- a/Language/Structure/Arithmetic Operators/addition.adoc
+++ b/Language/Structure/Arithmetic Operators/addition.adoc
@@ -24,17 +24,14 @@ subCategories: [ "Arithmetic Operators" ]
 
 [float]
 === Syntax
-[source,arduino]
-----
-sum = operand1 + operand2;
-----
+`sum = operand1 + operand2;`
 
 [float]
 === Parameters
-`sum` : variable. *Allowed data types:* int, float, double, byte, short, long +
-`operand1` : variable or constant. *Allowed data types:* int, float, double, byte, short, long +
-`operand2` : variable or constant. *Allowed data types:* int, float, double, byte, short, long
-[%hardbreaks]
+`sum`: variable. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`operand1`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`operand2`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`.
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Structure/Arithmetic Operators/division.adoc
+++ b/Language/Structure/Arithmetic Operators/division.adoc
@@ -24,17 +24,14 @@ subCategories: [ "Arithmetic Operators" ]
 
 [float]
 === Syntax
-[source,arduino]
-----
-result = numerator / denominator;
-----
+`result = numerator / denominator;`
+
 
 [float]
 === Parameters
-`result` : variable. *Allowed data types:* int, float, double, byte, short, long  +
-`numerator` : variable or constant. *Allowed data types:* int, float, double, byte, short, long  +
-`denominator` : *non zero* variable or constant. *Allowed data types:* int, float, double, byte, short, long
-[%hardbreaks]
+`result`: variable. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`numerator`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`denominator`: *non zero* variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Arithmetic Operators/multiplication.adoc
+++ b/Language/Structure/Arithmetic Operators/multiplication.adoc
@@ -24,17 +24,14 @@ subCategories: [ "Arithmetic Operators" ]
 
 [float]
 === Syntax
-[source,arduino]
-----
-product = operand1 * operand2;
-----
+`product = operand1 * operand2;`
+
 
 [float]
 === Parameters
-`product` : variable. *Allowed data types:* int, float, double, byte, short, long  +
-`operand1` : variable or constant. *Allowed data types:* int, float, double, byte, short, long  +
-`operand2` : variable or constant. *Allowed data types:* int, float, double, byte, short, long
-[%hardbreaks]
+`product`: variable. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`operand1`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`operand2`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Arithmetic Operators/remainder.adoc
+++ b/Language/Structure/Arithmetic Operators/remainder.adoc
@@ -24,17 +24,13 @@ subCategories: [ "Arithmetic Operators" ]
 
 [float]
 === Syntax
-[source,arduino]
-----
-remainder = dividend % divisor;
-----
+`remainder = dividend % divisor;`
 
 [float]
 === Parameters
-`remainder` : variable. *Allowed data types:* int, float, double +
-`dividend` : variable or constant. *Allowed data types:* int +
-`divisor` : *non zero* variable or constant. *Allowed data types:* int
-[%hardbreaks]
+`remainder`: variable. Allowed data types: `int`, `float`, `double`. +
+`dividend`: variable or constant. Allowed data types: `int`. +
+`divisor`: *non zero* variable or constant. Allowed data types: `int`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Arithmetic Operators/subtraction.adoc
+++ b/Language/Structure/Arithmetic Operators/subtraction.adoc
@@ -24,17 +24,14 @@ subCategories: [ "Arithmetic Operators" ]
 
 [float]
 === Syntax
-[source,arduino]
-----
-difference = operand1 - operand2;
-----
+`difference = operand1 - operand2;`
+
 
 [float]
 === Parameters
-`difference` : variable. *Allowed data types:* int, float, double, byte, short, long +
-`operand1` : variable or constant. *Allowed data types:* int, float, double, byte, short, long +
-`operand2` : variable or constant. *Allowed data types:* int, float, double, byte, short, long
-[%hardbreaks]
+`difference`: variable. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`operand1`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`operand2`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Bitwise Operators/bitshiftLeft.adoc
+++ b/Language/Structure/Bitwise Operators/bitshiftLeft.adoc
@@ -24,15 +24,13 @@ The left shift operator `<<` causes the bits of the left operand to be shifted *
 
 [float]
 === Syntax
-[source,arduino]
-----
-variable << number_of_bits;
-----
+`variable << number_of_bits;`
+
 
 [float]
 === Parameters
-`variable`: *Allowed data types:* byte, int, long +
-`number_of_bits`: a number that is < = 32. *Allowed data types:* int
+`variable`: Allowed data types: `byte`, `int`, `long`. +
+`number_of_bits`: a number that is < = 32. Allowed data types: `int`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Bitwise Operators/bitshiftRight.adoc
+++ b/Language/Structure/Bitwise Operators/bitshiftRight.adoc
@@ -24,15 +24,13 @@ The right shift operator `>>` causes the bits of the left operand to be shifted 
 
 [float]
 === Syntax
-[source,arduino]
-----
-variable >> number_of_bits;
-----
+`variable >> number_of_bits;`
+
 
 [float]
 === Parameters
-`variable`: *Allowed data types:* byte, int, long +
-`number_of_bits`: a number that is < = 32. *Allowed data types:* int
+`variable`: Allowed data types: `byte`, `int`, `long`. +
+`number_of_bits`: a number that is < = 32. Allowed data types: `int`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Comparison Operators/equalTo.adoc
+++ b/Language/Structure/Comparison Operators/equalTo.adoc
@@ -24,15 +24,13 @@ Compares the variable on the left with the value or variable on the right of the
 
 [float]
 === Syntax
-[source,arduino]
-----
-x == y; // is true if x is equal to y and it is false if x is not equal to y
-----
+`x == y; // is true if x is equal to y and it is false if x is not equal to y`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* int, float, double, byte, short, long +
-`y`: variable or constant. *Allowed data types:* int, float, double, byte, short, long
+`x`: variable. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`y`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Comparison Operators/greaterThan.adoc
+++ b/Language/Structure/Comparison Operators/greaterThan.adoc
@@ -24,15 +24,13 @@ Compares the variable on the left with the value or variable on the right of the
 
 [float]
 === Syntax
-[source,arduino]
-----
-x > y;  // is true if x is bigger than y and it is false if x is equal or smaller than y
-----
+`x > y;  // is true if x is bigger than y and it is false if x is equal or smaller than y`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* int, float, double, byte, short, long +
-`y`: variable or constant. *Allowed data types:* int, float, double, byte, short, long
+`x`: variable. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`y`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Comparison Operators/greaterThanOrEqualTo.adoc
+++ b/Language/Structure/Comparison Operators/greaterThanOrEqualTo.adoc
@@ -24,15 +24,13 @@ Compares the variable on the left with the value or variable on the right of the
 
 [float]
 === Syntax
-[source,arduino]
-----
-x >= y; // is true if x is bigger than or equal to y and it is false if x is smaller than y
-----
+`x >= y; // is true if x is bigger than or equal to y and it is false if x is smaller than y`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* int, float, double, byte, short, long +
-`y`: variable or constant. *Allowed data types:* int, float, double, byte, short, long
+`x`: variable. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`y`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Comparison Operators/lessThan.adoc
+++ b/Language/Structure/Comparison Operators/lessThan.adoc
@@ -24,15 +24,13 @@ Compares the variable on the left with the value or variable on the right of the
 
 [float]
 === Syntax
-[source,arduino]
-----
-x < y;  // is true if x is smaller than y and it is false if x is equal or bigger than y
-----
+`x < y;  // is true if x is smaller than y and it is false if x is equal or bigger than y`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* int, float, double, byte, short, long +
-`y`: variable or constant. *Allowed data types:* int, float, double, byte, short, long
+`x`: variable. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`y`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Comparison Operators/lessThanOrEqualTo.adoc
+++ b/Language/Structure/Comparison Operators/lessThanOrEqualTo.adoc
@@ -24,15 +24,13 @@ Compares the variable on the left with the value or variable on the right of the
 
 [float]
 === Syntax
-[source,arduino]
-----
-x <= y; // is true if x is smaller than or equal to y and it is false if x is greater than y
-----
+`x <= y; // is true if x is smaller than or equal to y and it is false if x is greater than y`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* int, float, double, byte, short, long +
-`y`: variable or constant. *Allowed data types:* int, float, double, byte, short, long
+`x`: variable. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`y`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Comparison Operators/notEqualTo.adoc
+++ b/Language/Structure/Comparison Operators/notEqualTo.adoc
@@ -24,15 +24,13 @@ Compares the variable on the left with the value or variable on the right of the
 
 [float]
 === Syntax
-[source,arduino]
-----
-x != y; // is false if x is equal to y and it is true if x is not equal to y
-----
+`x != y; // is false if x is equal to y and it is true if x is not equal to y`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* int, float, double, byte, short, long +
-`y`: variable or constant. *Allowed data types:* int, float, double, byte, short, long
+`x`: variable. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`y`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Compound Operators/compoundAddition.adoc
+++ b/Language/Structure/Compound Operators/compoundAddition.adoc
@@ -24,15 +24,13 @@ This is a convenient shorthand to perform addition on a variable with another co
 
 [float]
 === Syntax
-[source,arduino]
-----
-x += y; // equivalent to the expression x = x + y;
-----
+`x += y; // equivalent to the expression x = x + y;`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* int, float, double, byte, short, long +
-`y`: variable or constant. *Allowed data types:* int, float, double, byte, short, long
+`x`: variable. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`y`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Compound Operators/compoundBitwiseAnd.adoc
+++ b/Language/Structure/Compound Operators/compoundBitwiseAnd.adoc
@@ -31,15 +31,13 @@ A review of the Bitwise AND `&` operator:
 
 [float]
 === Syntax
-[source,arduino]
-----
-x &= y; // equivalent to x = x & y;
-----
+`x &= y; // equivalent to x = x & y;`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* char, int, long +
-`y`: variable or constant. *Allowed data types:* char, int, long
+`x`: variable. Allowed data types: `char`, `int`, `long`. +
+`y`: variable or constant. Allowed data types: `char`, `int`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Compound Operators/compoundBitwiseOr.adoc
+++ b/Language/Structure/Compound Operators/compoundBitwiseOr.adoc
@@ -27,15 +27,13 @@ A review of the Bitwise OR `|` operator:
 
 [float]
 === Syntax
-[source,arduino]
-----
-x |= y; // equivalent to x = x | y;
-----
+`x |= y; // equivalent to x = x | y;`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* char, int, long +
-`y`: variable or constant. *Allowed data types:* char, int, long
+`x`: variable. Allowed data types: `char`, `int`, `long`. +
+`y`: variable or constant. Allowed data types: `char`, `int`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Compound Operators/compoundBitwiseXor.adoc
+++ b/Language/Structure/Compound Operators/compoundBitwiseXor.adoc
@@ -27,15 +27,13 @@ A review of the Bitwise XOR `^` operator:
 
 [float]
 === Syntax
-[source,arduino]
-----
-x ^= y; // equivalent to x = x ^ y;
-----
+`x ^= y; // equivalent to x = x ^ y;`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* char, int, long +
-`y`: variable or constant. *Allowed data types:* char, int, long
+`x`: variable. Allowed data types: `char`, `int`, `long`. +
+`y`: variable or constant. Allowed data types: `char`, `int`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Compound Operators/compoundDivision.adoc
+++ b/Language/Structure/Compound Operators/compoundDivision.adoc
@@ -24,15 +24,13 @@ This is a convenient shorthand to perform division of a variable with another co
 
 [float]
 === Syntax
-[source,arduino]
-----
-x /= y; // equivalent to the expression x = x / y;
-----
+`x /= y; // equivalent to the expression x = x / y;`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* int, float, double, byte, short, long +
-`y`: *non zero* variable or constant. *Allowed data types:* int, float, double, byte, short, long
+`x`: variable. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`y`: *non zero* variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Compound Operators/compoundMultiplication.adoc
+++ b/Language/Structure/Compound Operators/compoundMultiplication.adoc
@@ -24,15 +24,13 @@ This is a convenient shorthand to perform multiplication of a variable with anot
 
 [float]
 === Syntax
-[source,arduino]
-----
-x *= y; // equivalent to the expression x = x * y;
-----
+`x *= y; // equivalent to the expression x = x * y;`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* int, float, double, byte, short, long +
-`y`: variable or constant. *Allowed data types:* int, float, double, byte, short, long
+`x`: variable. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`y`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Compound Operators/compoundRemainder.adoc
+++ b/Language/Structure/Compound Operators/compoundRemainder.adoc
@@ -24,15 +24,13 @@ This is a convenient shorthand to calculate the remainder when one integer is di
 
 [float]
 === Syntax
-[source,arduino]
-----
-x %= divisor;   // equivalent to the expression x = x % divisor;
-----
+`x %= divisor;   // equivalent to the expression x = x % divisor;`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* int +
-`divisor`: *non zero* variable or constant. *Allowed data types:* int
+`x`: variable. Allowed data types: `int`. +
+`divisor`: *non zero* variable or constant. Allowed data types: `int`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Compound Operators/compoundSubtraction.adoc
+++ b/Language/Structure/Compound Operators/compoundSubtraction.adoc
@@ -24,15 +24,13 @@ This is a convenient shorthand to perform subtraction of a constant or a variabl
 
 [float]
 === Syntax
-[source,arduino]
-----
-x -= y; // equivalent to the expression x = x - y;
-----
+`x -= y; // equivalent to the expression x = x - y;`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* int, float, double, byte, short, long +
-`y`: variable or constant. *Allowed data types:* int, float, double, byte, short, long
+`x`: variable. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`. +
+`y`: variable or constant. Allowed data types: `int`, `float`, `double`, `byte`, `short`, `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Compound Operators/decrement.adoc
+++ b/Language/Structure/Compound Operators/decrement.adoc
@@ -24,15 +24,14 @@ Decrements the value of a variable by 1.
 
 [float]
 === Syntax
-[source,arduino]
-----
-x--;  // decrement x by one and returns the old value of x
---x;  // decrement x by one and returns the new value of x
-----
+`x--;  // decrement x by one and returns the old value of x` +
+`--x;  // decrement x by one and returns the new value of x`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* integer, long (possibly unsigned)
+`x`: variable. Allowed data types: `int`, `long` (possibly unsigned).
+
 
 [float]
 === Returns

--- a/Language/Structure/Compound Operators/increment.adoc
+++ b/Language/Structure/Compound Operators/increment.adoc
@@ -24,15 +24,13 @@ Increments the value of a variable by 1.
 
 [float]
 === Syntax
-[source,arduino]
-----
-x++;  // increment x by one and returns the old value of x
-++x;  // increment x by one and returns the new value of x
-----
+`x++;  // increment x by one and returns the old value of x` +
+`++x;  // increment x by one and returns the new value of x`
+
 
 [float]
 === Parameters
-`x`: variable. *Allowed data types:* integer, long (possibly unsigned)
+`x`: variable. Allowed data types: `int`, `long` (possibly unsigned).
 
 [float]
 === Returns

--- a/Language/Structure/Control Structure/doWhile.adoc
+++ b/Language/Structure/Control Structure/doWhile.adoc
@@ -28,7 +28,11 @@ do {
   // statement block
 } while (condition);
 ----
-The `condition` is a boolean expression that evaluates to `true` or `false`.
+
+
+[float]
+=== Parameters
+`condition`: a boolean expression that evaluates to `true` or `false`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Control Structure/else.adoc
+++ b/Language/Structure/Control Structure/else.adoc
@@ -39,6 +39,7 @@ else {
   // do Thing C
 }
 ----
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Structure/Control Structure/for.adoc
+++ b/Language/Structure/Control Structure/for.adoc
@@ -30,8 +30,12 @@ for (initialization; condition; increment) {
 }
 ----
 
-The *initialization* happens first and exactly once. Each time through the loop, the *condition* is tested; if it's `true`, the statement block, and the *increment* is executed, then the *condition* is tested again. When the *condition* becomes `false`, the loop ends.
-[%hardbreaks]
+
+[float]
+=== Parameters
+`initialization`: happens first and exactly once. +
+`condition`: each time through the loop, `condition` is tested; if it's `true`, the statement block, and the *increment* is executed, then the *condition* is tested again. When the *condition* becomes `false`, the loop ends. +
+`increment`: executed each time through the loop when `contition` is true.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Control Structure/if.adoc
+++ b/Language/Structure/Control Structure/if.adoc
@@ -28,9 +28,20 @@ if (condition) {
 }
 ----
 
+
 [float]
 === Parameters
-condition: a boolean expression i.e., can be `true` or `false`
+`condition`: a boolean expression (i.e., can be `true` or `false`).
+
+--
+// OVERVIEW SECTION ENDS
+
+
+
+
+// HOW TO USE SECTION STARTS
+[#howtouse]
+--
 
 [float]
 === Example Code

--- a/Language/Structure/Control Structure/return.adoc
+++ b/Language/Structure/Control Structure/return.adoc
@@ -23,17 +23,13 @@ Terminate a function and return a value from a function to the calling function,
 
 [float]
 === Syntax
-[source,arduino]
-----
-return;
-
-return value; // both forms are valid
-----
+`return;` +
+`return value;`
 
 
 [float]
 === Parameters
-`value`: any variable or constant type
+`value`: Allowed data types: any variable or constant type.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Control Structure/switchCase.adoc
+++ b/Language/Structure/Control Structure/switchCase.adoc
@@ -44,8 +44,9 @@ switch (var) {
 
 [float]
 === Parameters
-`var`: a variable whose value to compare with various cases. *Allowed data types:* int, char +
-`label1`, `label2`: constants. *Allowed data types:* int, char
+`var`: a variable whose value to compare with various cases. Allowed data types: `int`, `char`. +
+`label1`, `label2`: constants. Allowed data types: `int`, `char`.
+
 
 [float]
 === Returns

--- a/Language/Structure/Control Structure/while.adoc
+++ b/Language/Structure/Control Structure/while.adoc
@@ -28,7 +28,11 @@ while (condition) {
   // statement(s)
 }
 ----
-The `condition` is a boolean expression that evaluates to `true` or `false`.
+
+
+[float]
+=== Parameters
+`condition`: a boolean expression that evaluates to `true` or `false`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Further Syntax/define.adoc
+++ b/Language/Structure/Further Syntax/define.adoc
@@ -29,12 +29,13 @@ In general, the link:../../../variables/variable-scope\--qualifiers/const[const]
 
 [float]
 === Syntax
-[source,arduino]
-----
-#define constantName value
-----
-Note that the # is necessary.
-[%hardbreaks]
+`#define constantName value`
+
+
+[float]
+=== Parameters
+`constantName`: the name of the macro to define. +
+`value`: the value to assign to the macro.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Conversion/byteCast.adoc
+++ b/Language/Variables/Conversion/byteCast.adoc
@@ -28,11 +28,12 @@ Converts a value to the link:../../data-types/byte[byte] data type.
 
 [float]
 === Parameters
-`x`: a value of any type
+`x`: a value. Allowed data types: any type.
+
 
 [float]
 === Returns
-`byte`
+Data type: `byte`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Conversion/charCast.adoc
+++ b/Language/Variables/Conversion/charCast.adoc
@@ -28,11 +28,12 @@ Converts a value to the link:../../data-types/char[char] data type.
 
 [float]
 === Parameters
-`x`: a value of any type
+`x`: a value. Allowed data types: any type.
+
 
 [float]
 === Returns
-`char`
+Data type: `char`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Conversion/floatCast.adoc
+++ b/Language/Variables/Conversion/floatCast.adoc
@@ -28,11 +28,12 @@ Converts a value to the link:../../data-types/float[float] data type.
 
 [float]
 === Parameters
-`x`: a value of any type
+`x`: a value. Allowed data types: any type.
+
 
 [float]
 === Returns
-`float`
+Data type: `float`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Conversion/intCast.adoc
+++ b/Language/Variables/Conversion/intCast.adoc
@@ -28,11 +28,12 @@ Converts a value to the link:../../data-types/int[int] data type.
 
 [float]
 === Parameters
-`x`: a value of any type
+`x`: a value. Allowed data types: any type.
+
 
 [float]
 === Returns
-`int`
+Data type: `int`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Conversion/longCast.adoc
+++ b/Language/Variables/Conversion/longCast.adoc
@@ -28,11 +28,12 @@ Converts a value to the link:../../data-types/long[long] data type.
 
 [float]
 === Parameters
-`x`: a value of any type
+`x`: a value. Allowed data types: any type.
+
 
 [float]
 === Returns
-`long`
+Data type: `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Conversion/wordcast.adoc
+++ b/Language/Variables/Conversion/wordcast.adoc
@@ -26,16 +26,17 @@ Converts a value to the link:../../data-types/word[word] data type.
 `word(x)` +
 `word(h, l)`
 
+
 [float]
 === Parameters
-`x`: a value of any type
+`x`: a value. Allowed data types: any type. +
+`h`: the high-order (leftmost) byte of the word. +
+`l`: the low-order (rightmost) byte of the word.
 
-`h`: the high-order (leftmost) byte of the word
 
-`l`: the low-order (rightmost) byte of the word
 [float]
 === Returns
-`word`
+Data type: `word`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/c_str.adoc
+++ b/Language/Variables/Data Types/String/Functions/c_str.adoc
@@ -26,9 +26,11 @@ Converts the contents of a String as a C-style, null-terminated string. Note tha
 === Syntax
 `myString.c_str()`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
+`myString`: a variable of type `String`.
+
 
 [float]
 === Returns

--- a/Language/Variables/Data Types/String/Functions/charAt.adoc
+++ b/Language/Variables/Data Types/String/Functions/charAt.adoc
@@ -26,11 +26,11 @@ Access a particular character of the String.
 === Syntax
 `myString.charAt(n)`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
-
-`n`: a variable of type unsigned int
+`myString`: a variable of type `String`. +
+`n`: a variable. Allowed data types: `unsigned int`.
 
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/compareTo.adoc
+++ b/Language/Variables/Data Types/String/Functions/compareTo.adoc
@@ -26,20 +26,19 @@ Compares two Strings, testing whether one comes before or after the other, or wh
 === Syntax
 `myString.compareTo(myString2)`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
-
-`myString2`: another variable of type String
+`myString`: a variable of type `String`. +
+`myString2`: another variable of type `String`.
 
 
 [float]
 === Returns
-`a negative number`: if myString comes before myString2
+`a negative number`: if myString comes before myString2. +
+`0`: if String equals myString2. +
+`a positive number`: if myString comes after myString2.
 
-`0`: if String equals myString2
-
-`a positive number`: if myString comes after myString2
 --
 
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/concat.adoc
+++ b/Language/Variables/Data Types/String/Functions/concat.adoc
@@ -26,16 +26,16 @@ Appends the parameter to a String.
 === Syntax
 `myString.concat(parameter)`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
+`myString`: a variable of type `String`. +
+`parameter`: Allowed data types: `String`, `string`, `char`, `byte`, `int`, `unsigned int`, `long`, `unsigned long`, `float`, `double`, `__FlashStringHelper`(`F()` macro).
 
-`parameter`: *Allowed types are* String, string, char, byte, int, unsigned int, long, unsigned long, float, double, __FlashStringHelper(F() macro).
 
 [float]
 === Returns
-`true`: success
-
+`true`: success. +
 `false`: failure (in which case the String is left unchanged).
 
 --

--- a/Language/Variables/Data Types/String/Functions/endsWith.adoc
+++ b/Language/Variables/Data Types/String/Functions/endsWith.adoc
@@ -26,18 +26,17 @@ Tests whether or not a String ends with the characters of another String.
 === Syntax
 `myString.endsWith(myString2)`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
-
-`myString2`: another variable of type String
+`myString`: a variable of type `String`. +
+`myString2`: another variable of type `String`.
 
 
 [float]
 === Returns
-`true`: if myString ends with the characters of myString2
-
-`false`: otherwise
+`true`: if myString ends with the characters of myString2. +
+`false`: otherwise.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/equals.adoc
+++ b/Language/Variables/Data Types/String/Functions/equals.adoc
@@ -26,16 +26,17 @@ Compares two Strings for equality. The comparison is case-sensitive, meaning the
 === Syntax
 `myString.equals(myString2)`
 
+
 [float]
 === Parameters
-`myString, myString2`: variables of type String
+`myString, myString2`: variables of type `String`.
 
 
 [float]
 === Returns
-`true`: if string equals string2 
+`true`: if string equals string2. +
+`false`: otherwise.
 
-`false`: otherwise
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/String/Functions/equalsIgnoreCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/equalsIgnoreCase.adoc
@@ -26,16 +26,18 @@ Compares two Strings for equality. The comparison is not case-sensitive, meaning
 === Syntax
 `myString.equalsIgnoreCase(myString2)`
 
+
 [float]
 === Parameters
-`myString, myString2`: variables of type String
+`myString`: variable of type `String`. +
+`myString2`: variable of type `String`.
 
 
 [float]
 === Returns
-`true`: if myString equals myString2 (ignoring case) 
+`true`: if myString equals myString2 (ignoring case). +
+`false`: otherwise.
 
-`false`: otherwise
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/String/Functions/getBytes.adoc
+++ b/Language/Variables/Data Types/String/Functions/getBytes.adoc
@@ -26,17 +26,17 @@ Copies the String's characters to the supplied buffer.
 === Syntax
 `myString.getBytes(buf, len)`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
+`myString`: a variable of type `String`. +
+`buf`: the buffer to copy the characters into. Allowed data types: array of `byte`s. +
+`len`: the size of the buffer. Allowed data types: `unsigned int`.
 
-`buf`: the buffer to copy the characters into (_byte []_)
-
-`len`: the size of the buffer (_unsigned int_)
 
 [float]
 === Returns
-None
+Nothing
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/indexOf.adoc
+++ b/Language/Variables/Data Types/String/Functions/indexOf.adoc
@@ -28,13 +28,13 @@ Locates a character or String within another String. By default, searches from t
 `myString.indexOf(val)` +
 `myString.indexOf(val, from)`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
+`myString`: a variable of type `String`. +
+`val`: the value to search for. Allowed data types: `char`, `String`. +
+`from`: the index to start the search from.
 
-`val`: the value to search for - char or String
-
-`from`: the index to start the search from
 
 [float]
 === Returns

--- a/Language/Variables/Data Types/String/Functions/lastIndexOf.adoc
+++ b/Language/Variables/Data Types/String/Functions/lastIndexOf.adoc
@@ -27,13 +27,12 @@ Locates a character or String within another String. By default, searches from t
 `myString.lastIndexOf(val)` +
 `myString.lastIndexOf(val, from)`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
-
-`val`: the value to search for - char or String
-
-`from`: the index to work backwards from
+`myString`: a variable of type `String`. +
+`val`: the value to search for. Allowed data types: `char`, `String`. +
+`from`: the index to work backwards from.
 
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/length.adoc
+++ b/Language/Variables/Data Types/String/Functions/length.adoc
@@ -26,9 +26,10 @@ Returns the length of the String, in characters. (Note that this doesn't include
 === Syntax
 `myString.length()`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
+`myString`: a variable of type `String`.
 
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/remove.adoc
+++ b/Language/Variables/Data Types/String/Functions/remove.adoc
@@ -27,18 +27,17 @@ Modify in place a String removing chars from the provided index to the end of th
 `myString.remove(index)` +
 `myString.remove(index, count)`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
-
-`index`: a variable of type unsigned int
-
-`count`: a variable of type unsigned int
+`myString`: a variable of type `String`. +
+`index`: The position at which to start the remove process (zero indexed). Allowed data types: `unsigned int`. +
+`count`: The number of characters to remove. Allowed data types: `unsigned int`.
 
 
 [float]
 === Returns
-None
+Nothing
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/replace.adoc
+++ b/Language/Variables/Data Types/String/Functions/replace.adoc
@@ -26,19 +26,18 @@ The String replace() function allows you to replace all instances of a given cha
 === Syntax
 `myString.replace(substring1, substring2)`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
-
-`substring1`: another variable of type String
-
-`substring2`: another variable of type String
-
+`myString`: a variable of type `String`. +
+`substring1`: another variable of type `String`. +
+`substring2`: another variable of type `String`.
 
 
 [float]
 === Returns
-None
+Nothing
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/String/Functions/reserve.adoc
+++ b/Language/Variables/Data Types/String/Functions/reserve.adoc
@@ -26,16 +26,17 @@ The String reserve() function allows you to allocate a buffer in memory for mani
 === Syntax
 `myString.reserve(size)`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
-
-`size`: unsigned int declaring the number of bytes in memory to save for String manipulation 
+`myString`: a variable of type `String`. +
+`size`: the number of bytes in memory to save for String manipulation. Allowed data types: `unsigned int`.
 
 
 [float]
 === Returns
-None
+Nothing
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/String/Functions/setCharAt.adoc
+++ b/Language/Variables/Data Types/String/Functions/setCharAt.adoc
@@ -26,18 +26,17 @@ Sets a character of the String. Has no effect on indices outside the existing le
 === Syntax
 `myString.setCharAt(index, c)`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
-
-`index`: the index to set the character at
-
-`c`: the character to store to the given location
+`myString`: a variable of type `String`. +
+`index`: the index to set the character at. +
+`c`: the character to store to the given location.
 
 
 [float]
 === Returns
-None
+Nothing
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/startsWith.adoc
+++ b/Language/Variables/Data Types/String/Functions/startsWith.adoc
@@ -26,16 +26,17 @@ Tests whether or not a String starts with the characters of another String.
 === Syntax
 `myString.startsWith(myString2)`
 
+
 [float]
 === Parameters
-`myString, myString2`: a variable of type String
+`myString, myString2`: a variable of type `String`.
 
 
 [float]
 === Returns
-`true`: if myString starts with the characters of myString2
-
+`true`: if myString starts with the characters of myString2. +
 `false`: otherwise
+
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/String/Functions/substring.adoc
+++ b/Language/Variables/Data Types/String/Functions/substring.adoc
@@ -27,13 +27,12 @@ Get a substring of a String. The starting index is inclusive (the corresponding 
 `myString.substring(from)` +
 `myString.substring(from, to)`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
-
-`from`: the index to start the substring at
-
-`to` (optional): the index to end the substring before
+`myString`: a variable of type `String`. +
+`from`: the index to start the substring at. +
+`to` (optional): the index to end the substring before.
 
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/toCharArray.adoc
+++ b/Language/Variables/Data Types/String/Functions/toCharArray.adoc
@@ -26,17 +26,17 @@ Copies the String's characters to the supplied buffer.
 === Syntax
 `myString.toCharArray(buf, len)`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
+`myString`: a variable of type `String`. +
+`buf`: the buffer to copy the characters into. Allowed data types: array of `char`s. +
+`len`: the size of the buffer. Allowed data types: `unsigned int`.
 
-`buf`: the buffer to copy the characters into (_char []_)
-
-`len`: the size of the buffer (_unsigned int_)
 
 [float]
 === Returns
-None
+Nothing
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toDouble.adoc
+++ b/Language/Variables/Data Types/String/Functions/toDouble.adoc
@@ -26,16 +26,15 @@ Converts a valid String to a double. The input String should start with a digit.
 === Syntax
 `myString.toDouble()`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
+`myString`: a variable of type `String`.
 
 
 [float]
 === Returns
-`double`
-
-If no valid conversion could be performed because the String doesn't start with a digit, a zero is returned.
+If no valid conversion could be performed because the String doesn't start with a digit, a zero is returned. Data type: `double`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toFloat.adoc
+++ b/Language/Variables/Data Types/String/Functions/toFloat.adoc
@@ -26,16 +26,15 @@ Converts a valid String to a float. The input String should start with a digit. 
 === Syntax
 `myString.toFloat()`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
+`myString`: a variable of type `String`.
 
 
 [float]
 === Returns
-`float`
-
-If no valid conversion could be performed because the String doesn't start with a digit, a zero is returned.
+If no valid conversion could be performed because the String doesn't start with a digit, a zero is returned. Data type: `float`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toInt.adoc
+++ b/Language/Variables/Data Types/String/Functions/toInt.adoc
@@ -26,16 +26,15 @@ Converts a valid String to an integer. The input String should start with an int
 === Syntax
 `myString.toInt()`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
+`myString`: a variable of type `String`.
 
 
 [float]
 === Returns
-`long`
-
-If no valid conversion could be performed because the String doesn't start with a integer number, a zero is returned.
+If no valid conversion could be performed because the String doesn't start with a integer number, a zero is returned. Data type: `long`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toLowerCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/toLowerCase.adoc
@@ -26,14 +26,15 @@ Get a lower-case version of a String. As of 1.0, toLowerCase() modifies the Stri
 === Syntax
 `myString.toLowerCase()`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
+`myString`: a variable of type `String`.
 
 
 [float]
 === Returns
-None
+Nothing
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toUpperCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/toUpperCase.adoc
@@ -25,14 +25,15 @@ Get an upper-case version of a String. As of 1.0, toUpperCase() modifies the Str
 === Syntax
 `myString.toUpperCase()`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
+`myString`: a variable of type `String`.
 
 
 [float]
 === Returns
-None
+Nothing
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/trim.adoc
+++ b/Language/Variables/Data Types/String/Functions/trim.adoc
@@ -26,14 +26,15 @@ Get a version of the String with any leading and trailing whitespace removed. As
 === Syntax
 `myString.trim()`
 
+
 [float]
 === Parameters
-`myString`: a variable of type String
+`myString`: a variable of type String.
 
 
 [float]
 === Returns
-None
+Nothing
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/append.adoc
+++ b/Language/Variables/Data Types/String/Operators/append.adoc
@@ -25,18 +25,17 @@ It concatenates Strings with other data.
 
 [float]
 === Syntax
-[source,arduino]
-----
-myString1 += data
-----
+`myString1 += data`
+
 
 [float]
 === Parameters
-`myString1` - a String variable
+`myString1`: a String variable.
+
 
 [float]
 === Returns
-None
+Nothing
 
 --
 

--- a/Language/Variables/Data Types/String/Operators/comparison.adoc
+++ b/Language/Variables/Data Types/String/Operators/comparison.adoc
@@ -22,20 +22,19 @@ Compares two Strings for equality. The comparison is case-sensitive, meaning the
 
 [float]
 === Syntax
-[source,arduino]
-----
-myString1 == myString2
-----
+`myString1 == myString2`
 
 [float]
 === Parameters
-`myString1, myString2` - a String variable
+`myString1`: a String variable. +
+`myString2`: a String variable.
+
 
 [float]
 === Returns
-`true`: if myString1 equals myString2
- 
-`false`: otherwise
+`true`: if myString1 equals myString2. + 
+`false`: otherwise.
+
 --
 
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/concatenation.adoc
+++ b/Language/Variables/Data Types/String/Operators/concatenation.adoc
@@ -25,18 +25,19 @@ Combines, or concatenates two Strings into one new String. The second String is 
 
 [float]
 === Syntax
-[source,arduino]
-----
-myString3 = myString1 + myString2
-----
+`myString3 = myString1 + myString2`
+
 
 [float]
 === Parameters
-`myString1, myString2, myString3` - a String variable
+`myString1`: a String variable. +
+`myString2`: a String variable. +
+`myString3`: a String variable.
+
 
 [float]
 === Returns
-new String that is the combination of the original two Strings.
+New String that is the combination of the original two Strings.
 
 --
 

--- a/Language/Variables/Data Types/String/Operators/differentFrom.adoc
+++ b/Language/Variables/Data Types/String/Operators/differentFrom.adoc
@@ -25,20 +25,19 @@ Compares two Strings for difference. The comparison is case-sensitive, meaning t
 
 [float]
 === Syntax
-[source,arduino]
-----
-myString1 != myString2
-----
+`myString1 != myString2`
+
 
 [float]
 === Parameters
-`myString1, myString2` - a String variable
+`myString1: a String variable. +
+`myString2`: a String variable.
+
 
 [float]
 === Returns
-`true`: if myString1 is different from myString2 
-
-`false`: otherwise
+`true`: if myString1 is different from myString2. +
+`false`: otherwise.
 
 --
 

--- a/Language/Variables/Data Types/String/Operators/elementAccess.adoc
+++ b/Language/Variables/Data Types/String/Operators/elementAccess.adoc
@@ -25,18 +25,15 @@ Allows you access to the individual characters of a String.
 
 [float]
 === Syntax
-[source,arduino]
-----
-char thisChar = myString1[n]
-----
+`char thisChar = myString1[n]`
+
 
 [float]
 === Parameters
-`char thisChar` - a character variable
+`thisChar`: Allowed data types: char. +
+`myString1`: Allowed data types: String. +
+`n`: a numeric variable.
 
-`myString1` - a String variable
-
-`int n` - a numeric variable
 
 [float]
 === Returns

--- a/Language/Variables/Data Types/String/Operators/greaterThan.adoc
+++ b/Language/Variables/Data Types/String/Operators/greaterThan.adoc
@@ -26,20 +26,19 @@ Caution: String comparison operators can be confusing when you're comparing nume
 
 [float]
 === Syntax
-[source,arduino]
-----
-myString1 > myString2
-----
+`myString1 > myString2`
+
 
 [float]
 === Parameters
-`myString1, myString2` - a String variable
+`myString1`: a String variable. +
+`myString2`: a String variable.
+
 
 [float]
 === Returns
-`true`: if myString1 is greater than myString2 
-
-`false`: otherwise
+`true`: if myString1 is greater than myString2. +
+`false`: otherwise.
 
 --
 

--- a/Language/Variables/Data Types/String/Operators/greaterThanOrEqualTo.adoc
+++ b/Language/Variables/Data Types/String/Operators/greaterThanOrEqualTo.adoc
@@ -22,21 +22,20 @@ Caution: String comparison operators can be confusing when you're comparing nume
 
 [float]
 === Syntax
-[source,arduino]
-----
-myString1 >= myString2
-----
+`myString1 >= myString2`
+
 
 [float]
 === Parameters
-`myString1, myString2`: variables of type String
+`myString1`: variable of type String. +
+`myString2: variable of type String.
 
 
 [float]
 === Returns
-`true`: if myString1 is greater than or equal to myString2
+`true`: if myString1 is greater than or equal to myString2. +
+`false`: otherwise.
 
-`false`: otherwise
 --
 
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/lessThan.adoc
+++ b/Language/Variables/Data Types/String/Operators/lessThan.adoc
@@ -22,20 +22,20 @@ Caution: String comparison operators can be confusing when you're comparing nume
 
 [float]
 === Syntax
-[source,arduino]
-----
-myString1 < myString2
-----
+`myString1 < myString2`
+
 
 [float]
 === Parameters
-`myString1, myString2`: variables of type String
+`myString1`: variable of type String. +
+`myString2`: variable of type String.
+
 
 [float]
 === Returns
-`true`: if myString1 is less than myString2
+`true`: if myString1 is less than myString2. +
+`false`: otherwise.
 
-`false`: otherwise
 --
 
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/lessThanOrEqualTo.adoc
+++ b/Language/Variables/Data Types/String/Operators/lessThanOrEqualTo.adoc
@@ -27,20 +27,19 @@ Caution: String comparison operators can be confusing when you're comparing nume
 
 [float]
 === Syntax
-[source,arduino]
-----
-myString1 <= myString2
-----
+`myString1 <= myString2`
+
 
 [float]
 === Parameters
-`myString1, myString2`: variables of type String
+`myString1`: variable of type String. +
+`myString2`: variable of type String.
+
 
 [float]
 === Returns
-`true`: if myString1 is less than or equal to myString2
-
-`false`: otherwise
+`true`: if myString1 is less than or equal to myString2. +
+`false`: otherwise.
 
 --
 

--- a/Language/Variables/Data Types/bool.adoc
+++ b/Language/Variables/Data Types/bool.adoc
@@ -25,8 +25,8 @@ A `bool` holds one of two values, `true` or `false`. (Each `bool` variable occup
 
 [float]
 === Parameters
-`var`: variable name +
-`val`: the value to assign to that variable
+`var`: variable name. +
+`val`: the value to assign to that variable.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/byte.adoc
+++ b/Language/Variables/Data Types/byte.adoc
@@ -23,8 +23,8 @@ A byte stores an 8-bit unsigned number, from 0 to 255.
 
 [float]
 === Parameters
-`var`: variable name +
-`val`: the value to assign to that variable
+`var`: variable name. +
+`val`: the value to assign to that variable.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/char.adoc
+++ b/Language/Variables/Data Types/char.adoc
@@ -27,8 +27,8 @@ The size of the `char` datatype is at least 8 bits. It's recommended to only use
 
 [float]
 === Parameters
-`var`: variable name +
-`val`: the value to assign to that variable
+`var`: variable name. +
+`val`: the value to assign to that variable.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/double.adoc
+++ b/Language/Variables/Data Types/double.adoc
@@ -25,8 +25,8 @@ On the Arduino Due, doubles have 8-byte (64 bit) precision.
 
 [float]
 === Parameters
-`var`: variable name +
-`val`: the value to assign to that variable
+`var`: variable name. +
+`val`: the value to assign to that variable.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/float.adoc
+++ b/Language/Variables/Data Types/float.adoc
@@ -34,9 +34,8 @@ If doing math with floats, you need to add a decimal point, otherwise it will be
 
 [float]
 === Parameters
-`var`: variable name +
-`val`: the value you assign to that variable
-[%hardbreaks]
+`var`: variable name. +
+`val`: the value you assign to that variable.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/int.adoc
+++ b/Language/Variables/Data Types/int.adoc
@@ -28,10 +28,11 @@ The Arduino takes care of dealing with negative numbers for you, so that arithme
 === Syntax
 `int var = val;`
 
+
 [float]
 === Parameters
-`var`: variable name +
-`val`: the value you assign to that variable
+`var`: variable name. +
+`val`: the value you assign to that variable.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/long.adoc
+++ b/Language/Variables/Data Types/long.adoc
@@ -24,15 +24,14 @@ If doing math with integers, at least one of the numbers must be followed by an 
 
 [float]
 === Syntax
-
 `long var = val;`
+
 
 [float]
 === Parameters
-`var`: variable name +
-`val`: the value assigned to the variable
+`var`: variable name. +
+`val`: the value assigned to the variable.
 
-[%hardbreaks]
 --
 // OVERVIEW SECTION ENDS
 

--- a/Language/Variables/Data Types/short.adoc
+++ b/Language/Variables/Data Types/short.adoc
@@ -26,10 +26,11 @@ On all Arduinos (ATMega and ARM based) a short stores a 16-bit (2-byte) value. T
 === Syntax
 `short var = val;`
 
+
 [float]
 === Parameters
-`var`: variable name +
-`val`: the value you assign to that variable
+`var`: variable name. +
+`val`: the value you assign to that variable.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/size_t.adoc
+++ b/Language/Variables/Data Types/size_t.adoc
@@ -23,8 +23,8 @@ subCategories: [ "Data Types" ]
 
 [float]
 === Parameters
-`var`: variable name +
-`val`: the value to assign to that variable
+`var`: variable name. +
+`val`: the value to assign to that variable.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/stringObject.adoc
+++ b/Language/Variables/Data Types/stringObject.adoc
@@ -49,22 +49,21 @@ gives you the String "1101", which is the binary representation of 13.
 
 [float]
 === Syntax
-[source,arduino]
-----
-String(val)
-String(val, base)
-String(val, decimalPlaces)
-----
+`String(val)` +
+`String(val, base)` +
+`String(val, decimalPlaces)`
+
 
 [float]
 === Parameters
-`val`:  a variable to format as a String - *Allowed data types:* string, char, byte, int, long, unsigned int, unsigned long, float, double +
-`base` (optional): the base in which to format an integral value +
-`decimalPlaces` (*only if val is float or double*): the desired decimal places
+`val`:  a variable to format as a String. Allowed data types: string, char, byte, int, long, unsigned int, unsigned long, float, double. +
+`base`: (optional) the base in which to format an integral value. +
+`decimalPlaces`: *only if val is float or double*. The desired decimal places.
+
 
 [float]
 === Returns
-an instance of the String class.
+An instance of the String class.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/unsignedChar.adoc
+++ b/Language/Variables/Data Types/unsignedChar.adoc
@@ -27,8 +27,8 @@ For consistency of Arduino programming style, the byte data type is to be prefer
 
 [float]
 === Parameters
-`var`: variable name +
-`val`: the value to assign to that variable
+`var`: variable name. +
+`val`: the value to assign to that variable.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/unsignedInt.adoc
+++ b/Language/Variables/Data Types/unsignedInt.adoc
@@ -19,17 +19,22 @@ The Due stores a 4 byte (32-bit) value, ranging from 0 to 4,294,967,295 (2^32 - 
 The difference between unsigned ints and (signed) ints, lies in the way the highest bit, sometimes referred to as the "sign" bit, is interpreted. In the Arduino int type (which is signed), if the high bit is a "1", the number is interpreted as a negative number, and the other 15 bits are interpreted with (http://en.wikipedia.org/wiki/2%27s_complement[2's complement math]).
 [%hardbreaks]
 
---
-// OVERVIEW SECTION ENDS
 
 [float]
 === Syntax
 `unsigned int var = val;`
 
+
 [float]
 === Parameters
-`var`: variable name +
-`val`: the value you assign to that variable
+`var`: variable name. +
+`val`: the value you assign to that variable.
+
+--
+// OVERVIEW SECTION ENDS
+
+
+
 
 // HOW TO USE SECTION STARTS
 [#howtouse]

--- a/Language/Variables/Data Types/unsignedLong.adoc
+++ b/Language/Variables/Data Types/unsignedLong.adoc
@@ -17,14 +17,13 @@ Unsigned long variables are extended size variables for number storage, and stor
 
 [float]
 === Syntax
-
 `unsigned long var = val;`
+
 
 [float]
 === Parameters
-`var`: variable name +
-`val`: the value you assign to that variable
-[%hardbreaks]
+`var`: variable name. +
+`val`: the value you assign to that variable.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/word.adoc
+++ b/Language/Variables/Data Types/word.adoc
@@ -23,8 +23,8 @@ A word can store an unsigned number of at least 16 bits (from 0 to 65535).
 
 [float]
 === Parameters
-`var`: variable name +
-`val`: the value to assign to that variable
+`var`: variable name. +
+`val`: the value to assign to that variable.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -24,16 +24,15 @@ The `PROGMEM` keyword is a variable modifier, it should be used only with the da
 PROGMEM is part of the link:http://www.nongnu.org/avr-libc/user-manual/group\__avr__pgmspace.html[pgmspace.h] library. It is included automatically in modern versions of the IDE, however if you are using an IDE version below 1.0 (2011), you'll first need to include the library at the top your sketch, like this:
 
 `#include <avr/pgmspace.h>`
+While `PROGMEM` could be used on a single variable, it is really only worth the fuss if you have a larger block of data that needs to be stored, which is usually easiest in an array, (or another C++ data structure beyond our present discussion).
+
+Using `PROGMEM` is also a two-step procedure. After getting the data into Flash memory, it requires special methods (functions), also defined in the link:http://www.nongnu.org/avr-libc/user-manual/group\__avr__pgmspace.html[pgmspace.h] library, to read the data from program memory back into SRAM, so we can do something useful with it.
 [%hardbreaks]
 
 
 [float]
 === Syntax
-
-const dataType variableName[] PROGMEM = {data0, data1, data3...};
-
-`dataType` - any variable type +
-`variableName` - the name for your array of data
+`const dataType variableName[] PROGMEM = {data0, data1, data3...};`
 
 Note that because PROGMEM is a variable modifier, there is no hard and fast rule about where it should go, so the Arduino compiler accepts all of the definitions below, which are also synonymous. However experiments have indicated that, in various versions of Arduino (having to do with GCC version), PROGMEM may work in one location and not in another. The "string table" example below has been tested to work with Arduino 13. Earlier versions of the IDE may work better if PROGMEM is included after the variable name.
 
@@ -42,10 +41,10 @@ Note that because PROGMEM is a variable modifier, there is no hard and fast rule
 `const dataType PROGMEM variableName[] = {};  // not this one`
 
 
-While `PROGMEM` could be used on a single variable, it is really only worth the fuss if you have a larger block of data that needs to be stored, which is usually easiest in an array, (or another C++ data structure beyond our present discussion).
-
-Using `PROGMEM` is also a two-step procedure. After getting the data into Flash memory, it requires special methods (functions), also defined in the link:http://www.nongnu.org/avr-libc/user-manual/group\__avr__pgmspace.html[pgmspace.h] library, to read the data from program memory back into SRAM, so we can do something useful with it.
-
+[float]
+=== Parameters
+`dataType`: Allowed data types: any variable type. +
+`variableName`: the name for your array of data.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -23,11 +23,12 @@ The `sizeof` operator returns the number of bytes in a variable type, or the num
 
 [float]
 === Parameters
-`variable`: any variable type or array (e.g. int, float, byte)
+`variable`: The thing to get the size of. Allowed data types: any variable type or array (e.g. `int`, `float`, `byte`).
+
 
 [float]
 === Returns
-The number of bytes in a variable or bytes occupied in an array. (size_t)
+The number of bytes in a variable or bytes occupied in an array. Data type: `size_t`.
 
 --
 // OVERVIEW SECTION ENDS


### PR DESCRIPTION
I have faithfully followed the standard established by the [reference sample](https://github.com/arduino/reference-en/blob/master/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Single_Entity.adoc). The exception is in documenting the return type, since the reference sample does not provide any guidance on this subject. In this, I attempted to be consistent with the standard established for documenting parameter types ("Allowed data types:" for parameters, "Data type:" for return type).

Note that this PR only reformats the existing content regarding parameter and return types. Documenting all parameter and return types will be done in a separate PR.

Fixes https://github.com/arduino/reference-en/pull/559