### PR TITLE
Use consistent link text for digital/analog pins tutorial links

### DIFF
--- a/Language/Functions/Analog IO/analogRead.adoc
+++ b/Language/Functions/Analog IO/analogRead.adoc
@@ -97,6 +97,6 @@ If the analog input pin is not connected to anything, the value returned by anal
 
 [role="language"]
 * #LANGUAGE# link:../../zero-due-mkr-family/analogreadresolution[analogReadResolution()]
-* #LANGUAGE# https://www.arduino.cc/en/Tutorial/AnalogInputPins[Tutorial: Analog Input Pins^]
+* #EXAMPLE# http://arduino.cc/en/Tutorial/AnalogInputPins[Description of the analog input pins^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Analog IO/analogReference.adoc
+++ b/Language/Functions/Analog IO/analogReference.adoc
@@ -87,7 +87,7 @@ Alternatively, you can connect the external reference voltage to the AREF pin th
 === See also
 
 [role="example"]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/AnalogInputPins[Description of analog input pins^]
+* #EXAMPLE# http://arduino.cc/en/Tutorial/AnalogInputPins[Description of the analog input pins^]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Digital IO/digitalRead.adoc
+++ b/Language/Functions/Digital IO/digitalRead.adoc
@@ -85,7 +85,7 @@ The analog input pins can be used as digital pins, referred to as A0, A1, etc. T
 === See also
 
 [role="example"]
-* #EXAMPLE# Tutorial: (http://arduino.cc/en/Tutorial/DigitalPins[Digital Pins])
+* #EXAMPLE# http://arduino.cc/en/Tutorial/DigitalPins[Description of the digital pins^]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Digital IO/digitalWrite.adoc
+++ b/Language/Functions/Digital IO/digitalWrite.adoc
@@ -89,7 +89,7 @@ The analog input pins can be used as digital pins, referred to as A0, A1, etc. T
 === See also
 
 [role="example"]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/DigitalPins[Tutorial: Digital Pins^]
+* #EXAMPLE# http://arduino.cc/en/Tutorial/DigitalPins[Description of the digital pins^]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Digital IO/pinMode.adoc
+++ b/Language/Functions/Digital IO/pinMode.adoc
@@ -17,7 +17,7 @@ subCategories: [ "Digital I/O" ]
 
 [float]
 === Description
-Configures the specified pin to behave either as an input or an output. See the description of (http://arduino.cc/en/Tutorial/DigitalPins[digital pins]) for details on the functionality of the pins.
+Configures the specified pin to behave either as an input or an output. See the http://arduino.cc/en/Tutorial/DigitalPins[Digital Pins] page for details on the functionality of the pins.
 [%hardbreaks]
 As of Arduino 1.0.1, it is possible to enable the internal pullup resistors with the mode INPUT_PULLUP. Additionally, the INPUT mode explicitly disables the internal pullups.
 [%hardbreaks]
@@ -31,7 +31,7 @@ As of Arduino 1.0.1, it is possible to enable the internal pullup resistors with
 === Parameters
 `pin`: the number of the pin whose mode you wish to set
 
-`mode`: `INPUT`, `OUTPUT`, or `INPUT_PULLUP`. (see the (http://arduino.cc/en/Tutorial/DigitalPins[digital pins]) page for a more complete description of the functionality.)
+`mode`: `INPUT`, `OUTPUT`, or `INPUT_PULLUP`. (see the http://arduino.cc/en/Tutorial/DigitalPins[Digital Pins] page for a more complete description of the functionality.)
 
 //Check how to add links
 
@@ -84,7 +84,7 @@ The analog input pins can be used as digital pins, referred to as A0, A1, etc.
 === See also
 
 [role="example"]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/DigitalPins[Description of the pins on an Arduino board^]
+* #EXAMPLE# http://arduino.cc/en/Tutorial/DigitalPins[Description of the digital pins^]
 
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
There was wide variation in the link text used to refer to these pages. I made the text consistent with the majority of the existing content.