### PR TITLE
Fix formatting of example code

### DIFF
--- a/AsciiDoc_sample/AsciiDoc_Dictionary/AsciiDoc_Template-Dictionary.adoc
+++ b/AsciiDoc_sample/AsciiDoc_Dictionary/AsciiDoc_Template-Dictionary.adoc
@@ -105,8 +105,8 @@ This is `code` in a sentence +
 This can be a lot more code 
 [source,arduino]
 ----
-for (int 1; i<=99; i++) {
-	Serial.println('We want more code!');
+for (int i = 0; i <= 99; i++) {
+  Serial.println('We want more code!');
 }
 ----
 [%hardbreaks]

--- a/Language/Structure/Control Structure/break.adoc
+++ b/Language/Structure/Control Structure/break.adoc
@@ -36,7 +36,7 @@ In the following code, the control exits the `for` loop when the sensor value ex
 [source,arduino]
 ----
 int threshold = 40;
-for (int x = 0; x < 255; x ++) {
+for (int x = 0; x < 255; x++) {
   analogWrite(PWMpin, x);
   sens = analogRead(sensorPin);
   if (sens > threshold) {     // bail out on sensor detect

--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -65,10 +65,10 @@ The following code fragments illustrate how to read and write unsigned chars (by
 [source,arduino]
 ----
 // save some unsigned ints
-const PROGMEM  uint16_t charSet[]  = { 65000, 32796, 16843, 10, 11234};
+const PROGMEM uint16_t charSet[] = { 65000, 32796, 16843, 10, 11234};
 
 // save some chars
-const char signMessage[] PROGMEM  = {"I AM PREDATOR,  UNSEEN COMBATANT. CREATED BY THE UNITED STATES DEPART"};
+const char signMessage[] PROGMEM = {"I AM PREDATOR,  UNSEEN COMBATANT. CREATED BY THE UNITED STATES DEPART"};
 
 unsigned int displayInt;
 char myChar;
@@ -88,7 +88,7 @@ void setup() {
 
   // read back a char
   for (byte k = 0; k < strlen_P(signMessage); k++) {
-    myChar =  pgm_read_byte_near(signMessage + k);
+    myChar = pgm_read_byte_near(signMessage + k);
     Serial.print(myChar);
   }
 


### PR DESCRIPTION
Fix formatting issues which were not covered by the auto format.

Fix formatting issues in AsciiDoc_Template-Dictionary.adoc, which I accidentally skipped during the auto format.