### PR TITLE
Update links to tone tutorials

### DIFF
--- a/Language/Functions/Advanced IO/tone.adoc
+++ b/Language/Functions/Advanced IO/tone.adoc
@@ -77,10 +77,10 @@ If you want to play different pitches on multiple pins, you need to call `noTone
 * #LANGUAGE# link:../../analog-io/analogwrite[analogWrite()]
 
 [role="example"]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone[Tone^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/toneMelody[Tone^]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/tonePitchFollower[Pitch follower^]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone3[Simple Keyboard^]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone4[multiple tones^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/toneKeyboard[Simple Keyboard^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/toneMultiple[multiple tones^]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/PWM[PWM^]
 
 --


### PR DESCRIPTION
The `tone` tutorial links use outdated URLs that must be redirected to the current URLs. It's better to point the links directly to the correct URL.

The "Pitch follower" URL was not updated because that is done in a separate PR (https://github.com/arduino/reference-en/pull/561).