### PR TITLE
Don't use a trailing slash on reference links

### DIFF
--- a/Language/Functions/Advanced IO/pulseIn.adoc
+++ b/Language/Functions/Advanced IO/pulseIn.adoc
@@ -32,7 +32,7 @@ The timing of this function has been determined empirically and will probably sh
 [float]
 === Parameters
 `pin`: the number of the Arduino pin on which you want to read the pulse. Allowed data types: `int`. +
-`value`: type of pulse to read: either link:../../../variables/constants/constants/[HIGH] or link:../../../variables/constants/constants/[LOW]. Allowed data types: `int`. +
+`value`: type of pulse to read: either link:../../../variables/constants/constants[HIGH] or link:../../../variables/constants/constants[LOW]. Allowed data types: `int`. +
 `timeout` (optional): the number of microseconds to wait for the pulse to start; default is one second. Allowed data types: `unsigned long`.
 
 

--- a/Language/Functions/Advanced IO/pulseInLong.adoc
+++ b/Language/Functions/Advanced IO/pulseInLong.adoc
@@ -34,7 +34,7 @@ The timing of this function has been determined empirically and will probably sh
 [float]
 === Parameters
 `pin`: the number of the Arduino pin on which you want to read the pulse. Allowed data types: `int`. +
-`value`: type of pulse to read: either link:../../../variables/constants/constants/[HIGH] or link:../../../variables/constants/constants/[LOW]. Allowed data types: `int`. +
+`value`: type of pulse to read: either link:../../../variables/constants/constants[HIGH] or link:../../../variables/constants/constants[LOW]. Allowed data types: `int`. +
 `timeout` (optional): the number of microseconds to wait for the pulse to start; default is one second. Allowed data types: `unsigned long`.
 
 

--- a/Language/Structure/Boolean Operators/logicalNot.adoc
+++ b/Language/Structure/Boolean Operators/logicalNot.adoc
@@ -32,7 +32,7 @@ subCategories: [ "Boolean Operators" ]
 
 [float]
 === Example Code
-This operator can be used inside the condition of an link:../../control-structure/if/[if] statement.
+This operator can be used inside the condition of an link:../../control-structure/if[if] statement.
 
 [source,arduino]
 ----

--- a/Language/Variables/Data Types/boolean.adoc
+++ b/Language/Variables/Data Types/boolean.adoc
@@ -12,7 +12,7 @@ subCategories: [ "Data Types" ]
 
 [float]
 === Description
-`boolean` is a non-standard type alias for link:../../../variables/data-types/bool/[bool] defined by Arduino. It's recommended to instead use the standard type `bool`, which is identical.
+`boolean` is a non-standard type alias for link:../../../variables/data-types/bool[bool] defined by Arduino. It's recommended to instead use the standard type `bool`, which is identical.
 
 
 [%hardbreaks]

--- a/Language/Variables/Data Types/int.adoc
+++ b/Language/Variables/Data Types/int.adoc
@@ -20,7 +20,7 @@ On the Arduino Due and SAMD based boards (like MKR1000 and Zero), an int stores 
 
 int's store negative numbers with a technique called (http://en.wikipedia.org/wiki/2%27s_complement[2's complement math]). The highest bit, sometimes referred to as the "sign" bit, flags the number as a negative number. The rest of the bits are inverted and 1 is added.
 
-The Arduino takes care of dealing with negative numbers for you, so that arithmetic operations work transparently in the expected manner. There can be an unexpected complication in dealing with the link:../../../structure/bitwise-operators/bitshiftright/[bitshift right operator] (>>) however.
+The Arduino takes care of dealing with negative numbers for you, so that arithmetic operations work transparently in the expected manner. There can be an unexpected complication in dealing with the link:../../../structure/bitwise-operators/bitshiftright[bitshift right operator] (>>) however.
 [%hardbreaks]
 
 
@@ -67,7 +67,7 @@ void loop() {
 
 [float]
 === Notes and Warnings
-When signed variables are made to exceed their maximum or minimum capacity they _overflow_. The result of an overflow is unpredictable so this should be avoided. A typical symptom of an overflow is the variable "rolling over" from its maximum capacity to its minimum or vice versa, but this is not always the case. If you want this behavior, use link:../unsignedint/[unsigned int].
+When signed variables are made to exceed their maximum or minimum capacity they _overflow_. The result of an overflow is unpredictable so this should be avoided. A typical symptom of an overflow is the variable "rolling over" from its maximum capacity to its minimum or vice versa, but this is not always the case. If you want this behavior, use link:../unsignedint[unsigned int].
 
 
 --


### PR DESCRIPTION
Following the standard established by the [sample reference pages](https://github.com/arduino/reference-en/blob/master/AsciiDoc_sample/Reference_Terms/AsciiDoc_Template-Single_Entity.adoc), don't put a trailing slash on links to Language Reference pages. Although either way works, it's better that all the links are consistent so that contributors don't waste time trying to figure out which style they need to use. I have left any trailing slashes as is on non-Language Reference links.