### PR TITLE
Fix code highlighting in streamReadBytesUntil.adoc and streamReadBytes.adoc.

### DIFF
--- a/Language/Functions/Communication/Stream/streamReadBytes.adoc
+++ b/Language/Functions/Communication/Stream/streamReadBytes.adoc
@@ -33,7 +33,7 @@ This function is part of the Stream class, and can be called by any class that i
 
 `buffer` : the buffer to store the bytes in (`char[]` or `byte[]`)
 
-`length` : the number of bytes to `read(int)`
+`length` : the number of bytes to read `(int)`
 
 [float]
 === Returns

--- a/Language/Functions/Communication/Stream/streamReadBytesUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamReadBytesUntil.adoc
@@ -35,7 +35,7 @@ This function is part of the Stream class, and can be called by any class that i
 
 `buffer`: the buffer to store the bytes in (`char[]` or `byte[]`)
 
-`length` : the number of bytes to `read(int)`
+`length` : the number of bytes to read `(int)`
 
 [float]
 === Returns


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-en/issues/580.