### PR TITLE
Fixed broken link and spelling in streamParseFloat.adoc.

### DIFF
--- a/Language/Functions/Communication/Stream/streamParseFloat.adoc
+++ b/Language/Functions/Communication/Stream/streamParseFloat.adoc
@@ -14,9 +14,9 @@ title: Stream.parseFloat()
 
 [float]
 === Description
-`parseFloat()` returns the first valid floating point number from the current position. Initial characters that are not digits (or the minus sign) are skipped. `parseFloat()` is terminated by the first character that is not a floating point number. The function terminates if it times out (see ../streamsettimeout[Stream.setTimeout()]).
+`parseFloat()` returns the first valid floating point number from the current position. Initial characters that are not digits (or the minus sign) are skipped. `parseFloat()` is terminated by the first character that is not a floating point number. The function terminates if it times out (see link:../streamsettimeout[Stream.setTimeout()]).
 
-This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more informatio
+This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 [%hardbreaks]
 
 


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-en/issues/583.