### PR TITLE
Correct syntax section of parseInt() reference pages

### DIFF
--- a/Language/Functions/Communication/Serial/parseInt.adoc
+++ b/Language/Functions/Communication/Serial/parseInt.adoc
@@ -21,7 +21,6 @@ Looks for the next valid integer in the incoming serial. The function terminates
 
 In particular:
 
-* Initial characters that are not digits or a minus sign, are skipped; +
 * Parsing stops when no characters have been read for a configurable time-out value, or a non-digit is read; +
 * If no valid digits were read when the time-out (see Serial.setTimeout()) occurs, 0 is returned;
 [%hardbreaks]
@@ -30,13 +29,20 @@ In particular:
 [float]
 === Syntax
 `_Serial_.parseInt()` +
-`_Serial_.parseInt(char skipChar)`
+`_Serial_.parseInt(lookahead)` +
+`_Serial_.parseInt(lookahead, ignore)`
 
 
 [float]
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
-`skipChar`: used to skip the indicated char in the search. Used for example to skip thousands divider.
+`lookahead`: the mode used to look ahead in the stream for an integer. Allowed data types: `LookaheadMode`. Allowed `lookahead` values:
+
+* `SKIP_ALL`: all characters other than digits or a minus sign are ignored when scanning the stream for an integer. This is the default mode.
+* `SKIP_NONE`: Nothing is skipped, and the stream is not touched unless the first waiting character is valid.
+* `SKIP_WHITESPACE`: Only tabs, spaces, line feeds, and carriage returns are skipped.
+
+`ignore`: used to skip the indicated char in the search. Used for example to skip thousands divider. Allowed data types: `char`
 
 [float]
 === Returns

--- a/Language/Functions/Communication/Stream/streamParseInt.adoc
+++ b/Language/Functions/Communication/Stream/streamParseInt.adoc
@@ -14,11 +14,10 @@ title: Stream.parseInt()
 
 [float]
 === Description
-`parseInt()` returns the first valid (long) integer number from the current position. Initial characters that are not integers (or the minus sign) are skipped.
+`parseInt()` returns the first valid (long) integer number from the current position.
 
 In particular:
 
-* Initial characters that are not digits or a minus sign, are skipped; +
 * Parsing stops when no characters have been read for a configurable time-out value, or a non-digit is read; +
 * If no valid digits were read when the time-out (see link:../streamsettimeout[Stream.setTimeout()]) occurs, 0 is returned;
 
@@ -28,17 +27,21 @@ This function is part of the Stream class, and can be called by any class that i
 
 [float]
 === Syntax
-`stream.parseInt(list)`
+`stream.parseInt()` +
+`stream.parseInt(lookahead)` +
+`stream.parseInt(lookahead, ignore)`
 
-`stream.parseInt(''list', char skipchar')`
 
 [float]
 === Parameters
-`stream` : an instance of a class that inherits from Stream.
+`stream` : an instance of a class that inherits from Stream. +
+`lookahead`: the mode used to look ahead in the stream for an integer. Allowed data types: `LookaheadMode`. Allowed `lookahead` values:
 
-`list` : the stream to check for ints (`char`)
+* `SKIP_ALL`: all characters other than digits or a minus sign are ignored when scanning the stream for an integer. This is the default mode.
+* `SKIP_NONE`: Nothing is skipped, and the stream is not touched unless the first waiting character is valid.
+* `SKIP_WHITESPACE`: Only tabs, spaces, line feeds, and carriage returns are skipped.
 
-`skipChar`: used to skip the indicated char in the search. Used for example to skip thousands divider.
+`ignore`: used to skip the indicated char in the search. Used for example to skip thousands divider. Allowed data types: `char`
 
 [float]
 === Returns


### PR DESCRIPTION
Both the `Stream.parseInt()` and `Serial.parseInt()` reference pages had erroneous information in their syntax documentation.

Reference:
https://github.com/arduino/ArduinoCore-API/blob/1.0.0/api/Stream.h#L86

Fixes https://github.com/arduino/reference-en/issues/588