### PR TITLE
Fix markup of bitWrite() example

### DIFF
--- a/Language/Functions/Bits and Bytes/bitWrite.adoc
+++ b/Language/Functions/Bits and Bytes/bitWrite.adoc
@@ -52,6 +52,7 @@ Demonstrates the use of bitWrite by printing the value of a variable to the Seri
 
 
 [source,arduino]
+----
 void setup() {
   Serial.begin(9600);
   while (!Serial) {}  // wait for serial port to connect. Needed for native USB port only


### PR DESCRIPTION
Incorrect markup caused part of the example code to be outside the code block:

![Clipboard01](https://user-images.githubusercontent.com/8572152/57121122-52664980-6d2a-11e9-9098-15121af783b0.png)
