### PR TITLE
Swap and correct the documentation of isSpace() and isWhitespace()

### DIFF
--- a/Language/Functions/Characters/isSpace.adoc
+++ b/Language/Functions/Characters/isSpace.adoc
@@ -17,7 +17,7 @@ subCategories: [ "Characters" ]
 
 [float]
 === Description
-Analyse if a char is the space character. Returns true if thisChar contains the space character.
+Analyse if a char is a white-space character. Returns true if the argument is a space, form feed (`'\f'`), newline (`'\n'`), carriage return (`'\r'`), horizontal tab (`'\t'`), or vertical tab (`'\v'`).
 [%hardbreaks]
 
 
@@ -34,7 +34,7 @@ isSpace(thisChar)
 
 [float]
 === Returns
-`true`: if thisChar is a space.
+`true`: if thisChar is a white-space character.
 
 --
 // OVERVIEW SECTION ENDS
@@ -50,11 +50,11 @@ isSpace(thisChar)
 
 [source,arduino]
 ----
-if (isSpace(myChar)) {  // tests if myChar is the space character
-  Serial.println("The character is a space");
+if (isSpace(myChar)) {  // tests if myChar is a white-space character
+  Serial.println("The character is white-space");
 }
 else {
-  Serial.println("The character is not a space");
+  Serial.println("The character is not white-space");
 }
 ----
 

--- a/Language/Functions/Characters/isWhitespace.adoc
+++ b/Language/Functions/Characters/isWhitespace.adoc
@@ -17,8 +17,7 @@ subCategories: [ "Characters" ]
 
 [float]
 === Description
-Analyse if a char is a white space, that is space, formfeed ('\f'), newline ('\n'), carriage return ('\r'), horizontal tab ('\t'), and vertical tab ('\v')).
-Returns true if thisChar contains a white space.
+Analyse if a char is a space character. Returns true if the argument is a space or horizontal tab (`'\t'`).
 [%hardbreaks]
 
 
@@ -34,7 +33,7 @@ isWhitespace(thisChar)
 
 [float]
 === Returns
-`true`: if thisChar is a white space.
+`true`: if thisChar is a space character.
 
 --
 // OVERVIEW SECTION ENDS
@@ -50,11 +49,11 @@ isWhitespace(thisChar)
 
 [source,arduino]
 ----
-if (isWhitespace(myChar)) { // tests if myChar is a white space
-  Serial.println("The character is a white space");
+if (isWhitespace(myChar)) { // tests if myChar is a space character
+  Serial.println("The character is a space or tab");
 }
 else {
-  Serial.println("The character is not a white space");
+  Serial.println("The character is not a space or tab");
 }
 ----
 


### PR DESCRIPTION
Although the documentation previously matched what you might expect these functions to do based on their names, the actual behavior of the functions is the reverse. In addition to this, `isWhitespace()` matches on horizontal tab as well as space, which was not mentioned in the `isSpace()` documentation. The decision was made to leave the long established implementation of the functions as-is to avoid causing breakage and to instead correct the documentation to match the actual behavior of the functions.

References:
- https://github.com/arduino/ArduinoCore-API/pull/27 (see demonstration sketch for proof of function behavior).
- Official decision to correct documentation rather than changing the behavior of the functions: https://github.com/arduino/ArduinoCore-API/pull/27#issuecomment-490122782
- https://github.com/arduino/ArduinoCore-API/blob/e1eb8de126786b7701b211332dda3f09aa400f35/api/WCharacter.h#L68-L72
- https://github.com/arduino/ArduinoCore-API/blob/e1eb8de126786b7701b211332dda3f09aa400f35/api/WCharacter.h#L118-L124

Fixes https://github.com/arduino/Arduino/issues/7041