### PR TITLE
Add missing "See also" section to stream reference page

### DIFF
--- a/Language/Functions/Communication/stream.adoc
+++ b/Language/Functions/Communication/stream.adoc
@@ -58,3 +58,14 @@ link:../stream/streamsettimeout[setTimeout()]
 
 --
 // FUNCTIONS SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS


### PR DESCRIPTION
When the "See also" section is missing, the automatically generated links to the other pages within the same subsection are added to a section titled "undefined".

![Clipboard01](https://user-images.githubusercontent.com/8572152/58512619-65661100-8152-11e9-9227-c4405c6042b5.png)

Related: https://github.com/arduino/reference-en/pull/488