### PR TITLE
Add ATmega32U4 documentation to analogReference() reference page

### DIFF
--- a/Language/Functions/Analog IO/analogReference.adoc
+++ b/Language/Functions/Analog IO/analogReference.adoc
@@ -19,10 +19,10 @@ subCategories: [ "Analog I/O" ]
 === Description
 Configures the reference voltage used for analog input (i.e. the value used as the top of the input range). The options are:
 
-Arduino AVR Boards (Uno, Mega, etc.)
+Arduino AVR Boards (Uno, Mega, Leonardo, etc.)
 
 * DEFAULT: the default analog reference of 5 volts (on 5V Arduino boards) or 3.3 volts (on 3.3V Arduino boards)
-* INTERNAL: an built-in reference, equal to 1.1 volts on the ATmega168 or ATmega328P and 2.56 volts on the ATmega8 (not available on the Arduino Mega)
+* INTERNAL: an built-in reference, equal to 1.1 volts on the ATmega168 or ATmega328P and 2.56 volts on the ATmega32U4 and ATmega8 (not available on the Arduino Mega)
 * INTERNAL1V1: a built-in 1.1V reference (Arduino Mega only)
 * INTERNAL2V56: a built-in 2.56V reference (Arduino Mega only)
 * EXTERNAL: the voltage applied to the AREF pin (0 to 5V only) is used as the reference.


### PR DESCRIPTION
- Add Leonardo to the list of example AVR boards. This covers all three current microcontrollers of the official AVR boards. I think most owners of the Micro understand that Leonardo documentation applies to it.
- Document `INTERNAL` reference voltage on ATmega32U4.