### PR TITLE
SerialPrintConc.adoc

### DIFF
--- a/Language/Functions/Communication/Serial/print.adoc
+++ b/Language/Functions/Communication/Serial/print.adoc
@@ -45,6 +45,14 @@ To send data without conversion to its representation as characters, use link:..
 `_Serial_.print(val)` +
 `_Serial_.print(val, format)`
 
+For you to concatenate multiple strings and variables on the same print line you simply use the '+' operator between the strings and if it is not a string, you must convert the variable you want to insert into a string. For example-
+
+* `Serial.println(“Hello, today is day” + String(x) + “, good Morning!”)`
+
+[float]
+=== Syntax
+`_Serial_.print(“String” + String(var))`
+
 
 [float]
 === Parameters


### PR DESCRIPTION

Most Arduino IDE users use various Serial.print() functions to print on the Serial monitor screen a one line sentence, using Multiple Serial.print (). In this project present a way to get the same result but only writing one line of theSerial.print () function.

For you to concatenate multiple strings and variables on the same print line you simply use the '+' operator between the strings and if it is not a string, you must convert the variable you want to insert into a string. For example-

* `Serial.println(“Hello, today is day” + String(x) + “, good Morning!”)`

[float]
=== Syntax
`_Serial_.print(“String” + String(var))`


https://create.arduino.cc/projecthub/SandroMesquita/function-serial-print-in-only-one-line-29ef8d?ref=platform&ref_id=424_trending___&offset=6