### PR TITLE
Typo Fixed in delayMicroseconds.adoc

### DIFF
--- a/Language/Functions/Time/delayMicroseconds.adoc
+++ b/Language/Functions/Time/delayMicroseconds.adoc
@@ -17,7 +17,7 @@ subCategories: [ "Time" ]
 
 [float]
 === Description
-Pauses the program for the amount of time (in microseconds) specified as parameter. There are a thousand microseconds in a millisecond, and a million microseconds in a second.
+Pauses the program for the amount of time (in microseconds) specified as the parameter. There are a thousand microseconds in a millisecond and a million microseconds in a second.
 
 Currently, the largest value that will produce an accurate delay is 16383. This could change in future Arduino releases. For delays longer than a few thousand microseconds, you should use `delay()` instead.
 [%hardbreaks]

--- a/Language/Functions/Time/delayMicroseconds.adoc
+++ b/Language/Functions/Time/delayMicroseconds.adoc
@@ -17,7 +17,7 @@ subCategories: [ "Time" ]
 
 [float]
 === Description
-Pauses the program for the amount of time (in microseconds) specified as the parameter. There are a thousand microseconds in a millisecond and a million microseconds in a second.
+Pauses the program for the amount of time (in microseconds) specified by the parameter. There are a thousand microseconds in a millisecond and a million microseconds in a second.
 
 Currently, the largest value that will produce an accurate delay is 16383. This could change in future Arduino releases. For delays longer than a few thousand microseconds, you should use `delay()` instead.
 [%hardbreaks]


### PR DESCRIPTION
Line 20
1. parameter requires an article before it.
2. unnecessary comma in a compound object.