### PR TITLE
Typos fixed in attachInterrupt.adoc

### DIFF
--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -70,7 +70,7 @@ For more information on interrupts, see http://gammon.com.au/interrupts[Nick Gam
 `mode`: defines when the interrupt should be triggered. Four constants are predefined as valid values: +
 
 * *LOW* to trigger the interrupt whenever the pin is low, +
-* *CHANGE* to trigger the interrupt whenever the pin changes the value +
+* *CHANGE* to trigger the interrupt whenever the pin changes value +
 * *RISING* to trigger when the pin goes from low to high, +
 * *FALLING* for when the pin goes from high to low. +
 

--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -41,15 +41,15 @@ Inside the attached function, `delay()` won't work and the value returned by `mi
 
 [float]
 == Using Interrupts
-Interrupts are useful for making things happen automatically in microcontroller programs, and can help solve timing problems. Good tasks for using an interrupt may include reading a rotary encoder, or monitoring user input.
+Interrupts are useful for making things happen automatically in microcontroller programs and can help solve timing problems. Good tasks for using an interrupt may include reading a rotary encoder, or monitoring user input.
 
-If you wanted to insure that a program always caught the pulses from a rotary encoder, so that it never misses a pulse, it would make it very tricky to write a program to do anything else, because the program would need to constantly poll the sensor lines for the encoder, in order to catch pulses when they occurred. Other sensors have a similar interface dynamic too, such as trying to read a sound sensor that is trying to catch a click, or an infrared slot sensor (photo-interrupter) trying to catch a coin drop. In all of these situations, using an interrupt can free the microcontroller to get some other work done while not missing the input.
+If you wanted to ensure that a program always caught the pulses from a rotary encoder, so that it never misses a pulse, it would make it very tricky to write a program to do anything else, because the program would need to constantly poll the sensor lines for the encoder, in order to catch pulses when they occurred. Other sensors have a similar interface, dynamic too, such as trying to read a sound sensor that is trying to catch a click, or an infrared slot sensor (photo-interrupter) trying to catch a coin drop. In all of these situations, using an interrupt can free the microcontroller to get some other work done while not missing the input.
 
 [float]
 == About Interrupt Service Routines
-ISRs are special kinds of functions that have some unique limitations most other functions do not have. An ISR cannot have any parameters, and they shouldn't return anything.
+ISRs are special kinds of functions that have some unique limitations, most other functions do not have. An ISR cannot have any parameters, and they shouldn't return anything.
 
-Generally, an ISR should be as short and fast as possible. If your sketch uses multiple ISRs, only one can run at a time, other interrupts will be executed after the current one finishes in an order that depends on the priority they have. `millis()` relies on interrupts to count, so it will never increment inside an ISR. Since `delay()` requires interrupts to work, it will not work if called inside an ISR. `micros()` works initially, but will start behaving erratically after 1-2 ms. `delayMicroseconds()` does not use any counter, so it will work as normal.
+Generally, an ISR should be as short and fast as possible. If your sketch uses multiple ISRs, only one can run at a time, other interrupts will be executed after the current one finishes in an order that depends on the priority they have. `millis()` relies on interrupts to count, so it will never increment inside an ISR. Since `delay()` requires interrupts to work, it will not work if called inside an ISR. `micros()` works initially but will start behaving erratically after 1-2 ms. `delayMicroseconds()` does not use any counter, so it will work as normal.
 
 Typically global variables are used to pass data between an ISR and the main program. To make sure variables shared between an ISR and the main program are updated correctly, declare them as `volatile`.
 
@@ -70,11 +70,11 @@ For more information on interrupts, see http://gammon.com.au/interrupts[Nick Gam
 `mode`: defines when the interrupt should be triggered. Four constants are predefined as valid values: +
 
 * *LOW* to trigger the interrupt whenever the pin is low, +
-* *CHANGE* to trigger the interrupt whenever the pin changes value +
+* *CHANGE* to trigger the interrupt whenever the pin changes the value +
 * *RISING* to trigger when the pin goes from low to high, +
 * *FALLING* for when the pin goes from high to low. +
 
-The Due, Zero and MKR1000 boards allows also: +
+The Due, Zero and MKR1000 boards allow also: +
 
 * *HIGH* to trigger the interrupt whenever the pin is high.
 
@@ -118,7 +118,7 @@ void blink() {
 
 [float]
 === Interrupt Numbers
-Normally you should use `digitalPinToInterrupt(pin)`, rather than place an interrupt number directly into your sketch. The specific pins with interrupts, and their mapping to interrupt number varies on each type of board. Direct use of interrupt numbers may seem simple, but it can cause compatibility trouble when your sketch is run on a different board.
+Normally you should use `digitalPinToInterrupt(pin)`, rather than place an interrupt number directly into your sketch. The specific pins with interrupts and their mapping to interrupt number varies for each type of board. Direct use of interrupt numbers may seem simple, but it can cause compatibility trouble when your sketch runs on a different board.
 
 However, older sketches often have direct interrupt numbers. Often number 0 (for digital pin 2) or number 1 (for digital pin 3) were used. The table below shows the available interrupt pins on various boards.
 

--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -47,7 +47,7 @@ If you wanted to ensure that a program always caught the pulses from a rotary en
 
 [float]
 == About Interrupt Service Routines
-ISRs are special kinds of functions that have some unique limitations, most other functions do not have. An ISR cannot have any parameters, and they shouldn't return anything.
+ISRs are special kinds of functions that have some unique limitations most other functions do not have. An ISR cannot have any parameters, and they shouldn't return anything.
 
 Generally, an ISR should be as short and fast as possible. If your sketch uses multiple ISRs, only one can run at a time, other interrupts will be executed after the current one finishes in an order that depends on the priority they have. `millis()` relies on interrupts to count, so it will never increment inside an ISR. Since `delay()` requires interrupts to work, it will not work if called inside an ISR. `micros()` works initially but will start behaving erratically after 1-2 ms. `delayMicroseconds()` does not use any counter, so it will work as normal.
 

--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -43,7 +43,7 @@ Inside the attached function, `delay()` won't work and the value returned by `mi
 == Using Interrupts
 Interrupts are useful for making things happen automatically in microcontroller programs and can help solve timing problems. Good tasks for using an interrupt may include reading a rotary encoder, or monitoring user input.
 
-If you wanted to ensure that a program always caught the pulses from a rotary encoder, so that it never misses a pulse, it would make it very tricky to write a program to do anything else, because the program would need to constantly poll the sensor lines for the encoder, in order to catch pulses when they occurred. Other sensors have a similar interface, dynamic too, such as trying to read a sound sensor that is trying to catch a click, or an infrared slot sensor (photo-interrupter) trying to catch a coin drop. In all of these situations, using an interrupt can free the microcontroller to get some other work done while not missing the input.
+If you wanted to ensure that a program always caught the pulses from a rotary encoder, so that it never misses a pulse, it would make it very tricky to write a program to do anything else, because the program would need to constantly poll the sensor lines for the encoder, in order to catch pulses when they occurred. Other sensors have a similar interface dynamic too, such as trying to read a sound sensor that is trying to catch a click, or an infrared slot sensor (photo-interrupter) trying to catch a coin drop. In all of these situations, using an interrupt can free the microcontroller to get some other work done while not missing the input.
 
 [float]
 == About Interrupt Service Routines


### PR DESCRIPTION
Line 44: 
Unnecessary comma in a compound predicate.

Line 46:
* ~~insure~~ to **ensure** (Requires suggestion).
* Addition of comma. 

Line 50: 
Addition of comma. 

Line 52: 
Unnecessary comma in a compound predicate.

Line 73: 
Addition of **the**

Line 77: 
the singular verb "allows" doesn't agree with the plural subject "boards"

Line 121: 
* Unnecessary comma in a compound predicate.
* ~~on~~ to **for**
* ~~is run~~ to **runs**