### PR TITLE
Use correct term for the waveform generated by analogWrite()

### DIFF
--- a/Language/Functions/Analog IO/analogWrite.adoc
+++ b/Language/Functions/Analog IO/analogWrite.adoc
@@ -17,7 +17,7 @@ subCategories: [ "Analog I/O" ]
 
 [float]
 === Description
-Writes an analog value (http://arduino.cc/en/Tutorial/PWM[PWM wave]) to a pin. Can be used to light a LED at varying brightnesses or drive a motor at various speeds. After a call to `analogWrite()`, the pin will generate a steady square wave of the specified duty cycle until the next call to `analogWrite()` (or a call to `digitalRead()` or `digitalWrite()`) on the same pin. 
+Writes an analog value (http://arduino.cc/en/Tutorial/PWM[PWM wave]) to a pin. Can be used to light a LED at varying brightnesses or drive a motor at various speeds. After a call to `analogWrite()`, the pin will generate a steady rectangular wave of the specified duty cycle until the next call to `analogWrite()` (or a call to `digitalRead()` or `digitalWrite()`) on the same pin. 
 [options="header"]
 |====================================================================================================
 | Board                | PWM Pins                        | PWM Frequency


### PR DESCRIPTION
A true square wave is only created by a PWM duty cycle of 50%. At any other duty cycle setting (including 50%), `analogWrite()` will create a rectangular wave.

Reported at:
https://forum.arduino.cc/index.php?topic=624267