### PR TITLE
Fixed code syntax related typo in pulseInLong.adoc

### DIFF
--- a/Language/Functions/Advanced IO/pulseInLong.adoc
+++ b/Language/Functions/Advanced IO/pulseInLong.adoc
@@ -76,7 +76,7 @@ void loop() {
 
 [float]
 === Notes and Warnings
-This function relies on micros() so cannot be used in link:../../interrupts/nointerrupts[noInterrupts()] context.
+This function relies on `micros()` so cannot be used in link:../../interrupts/nointerrupts[noInterrupts()] context.
 
 --
 // HOW TO USE SECTION ENDS


### PR DESCRIPTION
Fixed code syntax related typo
Ref: #612 