### PR TITLE
Fixed code syntax related typo find.adoc

### DIFF
--- a/Language/Functions/Communication/Serial/find.adoc
+++ b/Language/Functions/Communication/Serial/find.adoc
@@ -14,9 +14,9 @@ title: Serial.find()
 
 [float]
 === Description
-Serial.find() reads data from the serial buffer until the target is found. The function returns true if target is found, false if it times out.
+`Serial.find()` reads data from the serial buffer until the target is found. The function returns `true` if target is found, `false` if it times out.
 
-Serial.find() inherits from the link:../../stream[stream] utility class.
+`Serial.find()` inherits from the link:../../stream[stream] utility class.
 [%hardbreaks]
 
 


### PR DESCRIPTION
Fixed code syntax related typo
Ref: #612 