### PR TITLE
Content Position related Typo Fixed  bitSet.adoc

### DIFF
--- a/Language/Functions/Bits and Bytes/bitSet.adoc
+++ b/Language/Functions/Bits and Bytes/bitSet.adoc
@@ -12,12 +12,12 @@ subCategories: [ "Bits and Bytes" ]
 
 
 // OVERVIEW SECTION STARTS
-Sets (writes a 1 to) a bit of a numeric variable.
 [#overview]
 --
 
 [float]
 === Description
+Sets (writes a 1 to) a bit of a numeric variable.
 [%hardbreaks]
 
 


### PR DESCRIPTION
Fixed typo related to the correct position of the content.
Ref: https://github.com/arduino/reference-hi/pull/56 (Made changes to the Hindi Version too).