### PR TITLE
Update millis.adoc

### DIFF
--- a/Language/Functions/Time/millis.adoc
+++ b/Language/Functions/Time/millis.adoc
@@ -66,7 +66,7 @@ void loop() {
 === Notes and Warnings
 Please note that the return value for millis() is of type `unsigned long`, logic errors may occur if a programmer tries to do arithmetic with smaller data types such as `int`. Even signed `long` may encounter errors as its maximum value is half that of its unsigned counterpart.
 
-AVR-based architectures program a timer to implement millis(), reconfiguring these timers may result in inaccurate millis() readings. ArduinoCore-AVR relies on TIM0 which is programmed to generate an interrupt every 16384 clock cycles (clock divider set to 64, overflow every 256 ticks). The same holds for ArduinoCore-mega-AVR, except that it uses TIMx if MILLIS_USER_TIMx (0<=x<=3) is defined.
+On some architectures reconfiguration of timers may result in inaccurate millis() readings. AVR-based architectures program a timer to implement millis(): ArduinoCore-AVR programs TIM0 to generate an interrupt every 16384 clock cycles (clock divider set to 64, overflow every 256 ticks). The same holds for ArduinoCore-mega-AVR, except that it uses TIMx if MILLIS_USER_TIMx (0<=x<=3) is defined. The ArduinoCore-SAM(D) architectures rely on the Systick timer which is programmed to generate an interrupt every 1 ms.
 
 --
 // HOW TO USE SECTION ENDS

--- a/Language/Functions/Time/millis.adoc
+++ b/Language/Functions/Time/millis.adoc
@@ -64,7 +64,7 @@ void loop() {
 
 [float]
 === Notes and Warnings
-Please note that the return value for millis() is of type `unsigned long`, logic errors may occur if a programmer tries to do arithmetic with smaller data types such as `int`. Even signed `long` may encounter errors as its maximum value is half that of its unsigned counterpart.
+Please note that the return value for millis() is of type `unsigned long`, logic errors may occur if a programmer tries to do arithmetic with smaller data types such as `int`. Even signed `long` may encounter errors as its maximum value is half that of its unsigned counterpart. millis() uses timer0's overflow interrupt.
 
 --
 // HOW TO USE SECTION ENDS

--- a/Language/Functions/Time/millis.adoc
+++ b/Language/Functions/Time/millis.adoc
@@ -64,7 +64,9 @@ void loop() {
 
 [float]
 === Notes and Warnings
-Please note that the return value for millis() is of type `unsigned long`, logic errors may occur if a programmer tries to do arithmetic with smaller data types such as `int`. Even signed `long` may encounter errors as its maximum value is half that of its unsigned counterpart. millis() uses timer0's overflow interrupt.
+Please note that the return value for millis() is of type `unsigned long`, logic errors may occur if a programmer tries to do arithmetic with smaller data types such as `int`. Even signed `long` may encounter errors as its maximum value is half that of its unsigned counterpart.
+
+AVR-based architectures program a timer to implement millis(), reconfiguring these timers may result in inaccurate millis() readings. ArduinoCore-AVR relies on TIM0 which is programmed to generate an interrupt every 16384 clock cycles (clock divider set to 64, overflow every 256 ticks). The same holds for ArduinoCore-mega-AVR, except that it uses TIMx if MILLIS_USER_TIMx (0<=x<=3) is defined.
 
 --
 // HOW TO USE SECTION ENDS

--- a/Language/Functions/Time/millis.adoc
+++ b/Language/Functions/Time/millis.adoc
@@ -66,7 +66,7 @@ void loop() {
 === Notes and Warnings
 Please note that the return value for millis() is of type `unsigned long`, logic errors may occur if a programmer tries to do arithmetic with smaller data types such as `int`. Even signed `long` may encounter errors as its maximum value is half that of its unsigned counterpart.
 
-On some architectures reconfiguration of timers may result in inaccurate millis() readings. AVR-based architectures program a timer to implement millis(): ArduinoCore-AVR programs TIM0 to generate an interrupt every 16384 clock cycles (clock divider set to 64, overflow every 256 ticks). The same holds for ArduinoCore-mega-AVR, except that it uses TIMx if MILLIS_USER_TIMx (0<=x<=3) is defined. The ArduinoCore-SAM(D) architectures rely on the Systick timer which is programmed to generate an interrupt every 1 ms.
+On some architectures reconfiguration of timers may result in inaccurate millis() readings. AVR-based architectures program a timer to implement millis(): ArduinoCore-AVR programs TIM0 to generate an interrupt every 16384 clock cycles (clock divider set to 64, overflow every 256 ticks). The same holds for ArduinoCore-mega-AVR, except that it uses TIMx if MILLIS_USER_TIMx (0<=x<=3) is defined. The ArduinoCore-SAM(D) architectures program the Systick timer to generate an interrupt every 1 ms.
 
 --
 // HOW TO USE SECTION ENDS

--- a/Language/Functions/Time/millis.adoc
+++ b/Language/Functions/Time/millis.adoc
@@ -66,7 +66,7 @@ void loop() {
 === Notes and Warnings
 Please note that the return value for millis() is of type `unsigned long`, logic errors may occur if a programmer tries to do arithmetic with smaller data types such as `int`. Even signed `long` may encounter errors as its maximum value is half that of its unsigned counterpart.
 
-On some architectures reconfiguration of timers may result in inaccurate millis() readings. AVR-based architectures program a timer to implement millis(): ArduinoCore-AVR programs TIM0 to generate an interrupt every 16384 clock cycles (clock divider set to 64, overflow every 256 ticks). The same holds for ArduinoCore-mega-AVR, except that it uses TIMx if MILLIS_USER_TIMx (0<=x<=3) is defined. The ArduinoCore-SAM(D) architectures program the Systick timer to generate an interrupt every 1 ms.
+Reconfiguration of the microcontroller's timers may result in inaccurate `millis()` readings. The "Arduino AVR Boards" and "Arduino megaAVR Boards" cores use Timer0 to generate `millis()`. The "Arduino ARM (32-bits) Boards" and "Arduino SAMD (32-bits ARM Cortex-M0+) Boards" cores use the SysTick timer.
 
 --
 // HOW TO USE SECTION ENDS


### PR DESCRIPTION
Use of millis() may become unreliable if timer0 is reprogrammed, so a small warning might be useful that timer0 is used by millis().