### PR TITLE
Fixed wrong double quotes in examples.

### DIFF
--- a/Language/Functions/Communication/Serial/print.adoc
+++ b/Language/Functions/Communication/Serial/print.adoc
@@ -34,7 +34,7 @@ An optional second parameter specifies the base (format) to use; permitted value
 
 You can pass flash-memory based strings to `_Serial_.print()` by wrapping them with link:../../../../variables/utilities/progmem[F()]. For example:
 
-`Serial.print(F(“Hello World”))`
+`Serial.print(F("Hello World"))`
 
 To send data without conversion to its representation as characters, use link:../write[Serial.write()].
 [%hardbreaks]

--- a/Language/Functions/Communication/Serial/write.adoc
+++ b/Language/Functions/Communication/Serial/write.adoc
@@ -58,7 +58,7 @@ void setup() {
 void loop() {
   Serial.write(45); // send a byte with the value 45
 
-  int bytesSent = Serial.write(“hello”);  //send the string “hello” and return the length of the string.
+  int bytesSent = Serial.write("hello");  //send the string "hello" and return the length of the string.
 }
 ----
 [%hardbreaks]


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-en/issues/699.