### PR TITLE
Fixed markdown errors with chars after a code block.

### DIFF
--- a/Language/Functions/Communication/Serial/readBytes.adoc
+++ b/Language/Functions/Communication/Serial/readBytes.adoc
@@ -30,7 +30,7 @@ title: Serial.readBytes()
 [float]
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
-`buffer`: the buffer to store the bytes in. Allowed data types: or array of `char` or `byte`s. +
+`buffer`: the buffer to store the bytes in. Allowed data types: or array of `char` or `byte`. +
 `length`: the number of bytes to read. Allowed data types: `int`.
 
 

--- a/Language/Functions/Communication/Serial/readBytesUntil.adoc
+++ b/Language/Functions/Communication/Serial/readBytesUntil.adoc
@@ -31,7 +31,7 @@ Serial.readBytesUntil() reads characters from the serial buffer into an array. T
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
 `character`: the character to search for. Allowed data types: `char`. +
-`buffer`: the buffer to store the bytes in. Allowed data types: array of `char` or `byte`s. +
+`buffer`: the buffer to store the bytes in. Allowed data types: array of `char` or `byte`. +
 `length`: the number of bytes to read. Allowed data types: `int`.
 
 

--- a/Language/Functions/Communication/Stream/streamReadBytes.adoc
+++ b/Language/Functions/Communication/Stream/streamReadBytes.adoc
@@ -30,7 +30,7 @@ This function is part of the Stream class, and can be called by any class that i
 [float]
 === Parameters
 `stream`: an instance of a class that inherits from Stream. +
-`buffer`: the buffer to store the bytes in. Allowed data types: array of `char` or `byte`s. +
+`buffer`: the buffer to store the bytes in. Allowed data types: array of `char` or `byte`. +
 `length`: the number of bytes to read. Allowed data types: `int`.
 
 

--- a/Language/Functions/Communication/Stream/streamReadBytesUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamReadBytesUntil.adoc
@@ -31,7 +31,7 @@ This function is part of the Stream class, and can be called by any class that i
 === Parameters
 `stream`: an instance of a class that inherits from Stream. +
 `character`: the character to search for. Allowed data types: `char`. +
-`buffer`: the buffer to store the bytes in. Allowed data types: array of `char` or `byte`s. +
+`buffer`: the buffer to store the bytes in. Allowed data types: array of `char` or `byte`. +
 `length`: the number of bytes to read. Allowed data types: `int`.
 
 

--- a/Language/Variables/Data Types/String/Functions/getBytes.adoc
+++ b/Language/Variables/Data Types/String/Functions/getBytes.adoc
@@ -30,7 +30,7 @@ Copies the String's characters to the supplied buffer.
 [float]
 === Parameters
 `myString`: a variable of type `String`. +
-`buf`: the buffer to copy the characters into. Allowed data types: array of `byte`s. +
+`buf`: the buffer to copy the characters into. Allowed data types: array of `byte`. +
 `len`: the size of the buffer. Allowed data types: `unsigned int`.
 
 

--- a/Language/Variables/Data Types/String/Functions/toCharArray.adoc
+++ b/Language/Variables/Data Types/String/Functions/toCharArray.adoc
@@ -30,7 +30,7 @@ Copies the String's characters to the supplied buffer.
 [float]
 === Parameters
 `myString`: a variable of type `String`. +
-`buf`: the buffer to copy the characters into. Allowed data types: array of `char`s. +
+`buf`: the buffer to copy the characters into. Allowed data types: array of `char`. +
 `len`: the size of the buffer. Allowed data types: `unsigned int`.
 
 


### PR DESCRIPTION
From https://github.com/arduino/reference-en/pull/701:

I have checked the plural occurences with the following regex'es:

```regex
`String()`[a-zA-Z]
`array`[a-zA-Z]
`bool`[a-zA-Z]
`boolean`[a-zA-Z]
`byte`[a-zA-Z]
`char`[a-zA-Z]
`double`[a-zA-Z]
`float`[a-zA-Z]
`int`[a-zA-Z]
`long`[a-zA-Z]
`short`[a-zA-Z]
`size_t`[a-zA-Z]
`string`[a-zA-Z]
`unsigned char`[a-zA-Z]
`unsigned int`[a-zA-Z]
`unsigned long`[a-zA-Z]
`void`[a-zA-Z]
`word`[a-zA-Z]
```

including all data types from https://www.arduino.cc/reference/en/#variables.

This should fix all the markdown issues with this kind of error.