### PR TITLE
Update volatile.adoc: Add explanation to examples

### DIFF
--- a/Language/Variables/Variable Scope & Qualifiers/volatile.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/volatile.adoc
@@ -55,14 +55,14 @@ There are several ways to do this:
 === Example Code
 // Describe what the example code is all about and add relevant code   ►►►►► THIS SECTION IS MANDATORY ◄◄◄◄◄
 
-The `volatile` modifier ensures that changes to the `state` variable are immediately visible in `loop()`. Without the `volatile` modifier, the `state` variable would be loaded into a register when entering the function and would not be updated anymore until the function ends.
+The `volatile` modifier ensures that changes to the `state` variable are immediately visible in `loop()`. Without the `volatile` modifier, the `state` variable may be loaded into a register when entering the function and would not be updated anymore until the function ends.
 
 [source,arduino]
 ----
 // Flashes the LED for 1 s if the input has changed
 // in the previous second.
 
-volatile byte state = LOW;
+volatile byte changed = 0;
 
 void setup() {
   pinMode(LED_BUILTIN, OUTPUT);
@@ -70,22 +70,21 @@ void setup() {
 }
 
 void loop() {
-  bool changedInTheMeantime = false;
+  if (changed == 1) {
+    // toggle() has been called from interrupts!
 
-  byte originalState = state;
-  delay(1000);
-  byte newState = state;
+    // Reset changed to 0
+    changed = 0;
 
-  if (newState != originalState) {
-    // toggle() has been called during delay(1000)
-    changedInTheMeantime = true;
+    // Blink LED for 200 ms
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(200);
+    digitalWrite(LED_BUILTIN, LOW);
   }
-
-  digitalWrite(LED_BUILTIN, changedInTheMeantime ? HIGH : LOW);
 }
 
 void toggle() {
-  state = !state;
+  changed = 1;
 }
 ----
 

--- a/Language/Variables/Variable Scope & Qualifiers/volatile.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/volatile.adoc
@@ -55,6 +55,7 @@ There are several ways to do this:
 === Example Code
 // Describe what the example code is all about and add relevant code   ►►►►► THIS SECTION IS MANDATORY ◄◄◄◄◄
 
+Use a `volatile byte` to store the pin state in a single byte:
 
 [source,arduino]
 ----
@@ -77,16 +78,19 @@ void blink() {
 }
 ----
 
+Use an atomic block for atomic access to a 16-bit `int`:
 
 [source,arduino]
 ----
 #include <util/atomic.h> // this library includes the ATOMIC_BLOCK macro.
 volatile int input_from_interrupt;
 
+void loop() {
   ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     // code with interrupts blocked (consecutive atomic operations will not get interrupted)
     int result = input_from_interrupt;
   }
+}
 ----
 
 

--- a/Language/Variables/Variable Scope & Qualifiers/volatile.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/volatile.adoc
@@ -55,42 +55,52 @@ There are several ways to do this:
 === Example Code
 // Describe what the example code is all about and add relevant code   ►►►►► THIS SECTION IS MANDATORY ◄◄◄◄◄
 
-Use a `volatile byte` to store the pin state in a single byte:
+The `volatile` modifier ensures that changes to the `state` variable are immediately visible in `loop()`. Without the `volatile` modifier, the `state` variable would be loaded into a register when entering the function and would not be updated anymore until the function ends.
 
 [source,arduino]
 ----
-// toggles LED when interrupt pin changes state
+// Flashes the LED for 1 s if the input has changed
+// in the previous second.
 
-int pin = 13;
 volatile byte state = LOW;
 
 void setup() {
-  pinMode(pin, OUTPUT);
-  attachInterrupt(digitalPinToInterrupt(2), blink, CHANGE);
+  pinMode(LED_BUILTIN, OUTPUT);
+  attachInterrupt(digitalPinToInterrupt(2), toggle, CHANGE);
 }
 
 void loop() {
-  digitalWrite(pin, state);
+  bool changedInTheMeantime = false;
+
+  byte originalState = state;
+  delay(1000);
+  byte newState = state;
+
+  if (newState != originalState) {
+    // toggle() has been called during delay(1000)
+    changedInTheMeantime = true;
+  }
+
+  digitalWrite(LED_BUILTIN, changedInTheMeantime ? HIGH : LOW);
 }
 
-void blink() {
+void toggle() {
   state = !state;
 }
 ----
 
-Use an atomic block for atomic access to a 16-bit `int`:
+To access a variable with size greater than the microcontroller’s 8-bit data bus, use the `ATOMIC_BLOCK` macro. The macro ensures that the variable is read in an atomic operation, i.e. its contents cannot be altered while it is being read.
 
 [source,arduino]
 ----
 #include <util/atomic.h> // this library includes the ATOMIC_BLOCK macro.
 volatile int input_from_interrupt;
 
-void loop() {
+// Somewhere in the code, e.g. inside loop()
   ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     // code with interrupts blocked (consecutive atomic operations will not get interrupted)
     int result = input_from_interrupt;
   }
-}
 ----
 
 


### PR DESCRIPTION
This change also adds a visual separator between the two code blocks so it is clear that they do not belong together.