### PR TITLE
Document interrupt pins for new Nano boards

### DIFF
--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -21,11 +21,13 @@ The first parameter to `attachInterrupt()` is an interrupt number. Normally you 
 |===================================================
 |Board                             |Digital Pins Usable For Interrupts
 |Uno, Nano, Mini, other 328-based  |2, 3
-|Uno WiFi Rev.2                    |all digital pins
+|Uno WiFi Rev.2, Nano Every        |all digital pins
 |Mega, Mega2560, MegaADK           |2, 3, 18, 19, 20, 21
 |Micro, Leonardo, other 32u4-based |0, 1, 2, 3, 7
 |Zero                              |all digital pins, except 4
 |MKR Family boards                 |0, 1, 4, 5, 6, 7, 8, 9, A1, A2
+|Nano 33 IoT                       |2, 3, 9, 10, 11, 13, 15, A5, A7
+|Nano 33 BLE, Nano 33 BLE Sense    |all pins
 |Due                               |all digital pins
 |101                               |all digital pins (Only pins 2, 5, 7, 8, 10, 11, 12, 13 work with *CHANGE*)
 |===================================================


### PR DESCRIPTION
Document the pins that can be used with `attachInterrupt()` on the Nano Every/33 IoT/33 BLE/33 BLE Sense.