### PR TITLE
[vishnu] typo corrected.

### DIFF
--- a/Language/Functions/Communication/Serial/readBytes.adoc
+++ b/Language/Functions/Communication/Serial/readBytes.adoc
@@ -30,7 +30,7 @@ title: Serial.readBytes()
 [float]
 === Parameters
 `_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
-`buffer`: the buffer to store the bytes in. Allowed data types: or array of `char` or `byte`. +
+`buffer`: the buffer to store the bytes in. Allowed data types: array of `char` or `byte`. +
 `length`: the number of bytes to read. Allowed data types: `int`.
 
 


### PR DESCRIPTION
Removed an unnecessary 'or' that was present in the description of buffer under parameters. 