### PR TITLE
Update analogWrite.adoc

### DIFF
--- a/Language/Functions/Analog IO/analogWrite.adoc
+++ b/Language/Functions/Analog IO/analogWrite.adoc
@@ -51,6 +51,8 @@ The `analogWrite` function has nothing to do with the analog pins or the `analog
 `pin`: the Arduino pin to write to. Allowed data types: `int`. +
 `value`: the duty cycle: between 0 (always off) and 255 (always on). Allowed data types: `int`.
 
+Due* The duty cycle on the Due is between 0 (always off) and 4095 (always on). 16bits resolution.
+
 
 [float]
 === Returns

--- a/Language/Functions/Analog IO/analogWrite.adoc
+++ b/Language/Functions/Analog IO/analogWrite.adoc
@@ -51,7 +51,7 @@ The `analogWrite` function has nothing to do with the analog pins or the `analog
 `pin`: the Arduino pin to write to. Allowed data types: `int`. +
 `value`: the duty cycle: between 0 (always off) and 255 (always on). Allowed data types: `int`.
 
-Due* The duty cycle on the Due is between 0 (always off) and 4095 (always on). 16bits resolution.
+Due* The duty cycle on the Due is between 0 (always off) and 4095 (always on). 12bits resolution.
 
 
 [float]


### PR DESCRIPTION
The documentation fails to mention that the Due PMW resolution is 12bits, 0 - 4095.  Upon reading this you would assume its between 0 - 255, and most people won't be measuring the pins duty cycle and will find that they cannot reach above 6% duty with 255.