### PR TITLE
Fix incorrect case in link to noTone() reference page

### DIFF
--- a/Language/Functions/Advanced IO/tone.adoc
+++ b/Language/Functions/Advanced IO/tone.adoc
@@ -17,7 +17,7 @@ subCategories: [ "Advanced I/O" ]
 
 [float]
 === Description
-Generates a square wave of the specified frequency (and 50% duty cycle) on a pin. A duration can be specified, otherwise the wave continues until a call to link:../noTone[noTone()]. The pin can be connected to a piezo buzzer or other speaker to play tones.
+Generates a square wave of the specified frequency (and 50% duty cycle) on a pin. A duration can be specified, otherwise the wave continues until a call to link:../notone[noTone()]. The pin can be connected to a piezo buzzer or other speaker to play tones.
 
 Only one tone can be generated at a time. If a tone is already playing on a different pin, the call to `tone()` will have no effect. If the tone is playing on the same pin, the call will set its frequency.
 


### PR DESCRIPTION
The incorrect case of the link caused it to not work (all reference URLs are lowercase).

Fixes https://github.com/arduino/reference-en/issues/736 (thanks @thearduinoguy!)