### PR TITLE
Correct internal links in the Keyboard section

### DIFF
--- a/Language/Functions/USB/Keyboard/keyboardBegin.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardBegin.adoc
@@ -14,7 +14,7 @@ title: Keyboard.begin()
 
 [float]
 === Description
-When used with a Leonardo or Due board, `Keyboard.begin()` starts emulating a keyboard connected to a computer. To end control, use link:../keyboardend[Keyboard.end()].
+When used with a Leonardo or Due board, `Keyboard.begin()` starts emulating a keyboard connected to a computer. To end control, use link:../keyboard/keyboardend[Keyboard.end()].
 [%hardbreaks]
 
 

--- a/Language/Functions/USB/Keyboard/keyboardEnd.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardEnd.adoc
@@ -14,7 +14,7 @@ title: Keyboard.end()
 
 [float]
 === Description
-Stops the keyboard emulation to a connected computer. To start keyboard emulation, use link:../keyboardbegin[Keyboard.begin()].
+Stops the keyboard emulation to a connected computer. To start keyboard emulation, use link:../keyboard/keyboardbegin[Keyboard.begin()].
 [%hardbreaks]
 
 

--- a/Language/Functions/USB/Keyboard/keyboardPress.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPress.adoc
@@ -14,9 +14,9 @@ title: Keyboard.press()
 
 [float]
 === Description
-When called, `Keyboard.press()` functions as if a key were pressed and held on your keyboard. Useful when using link:../keyboardmodifiers[modifier keys]. To end the key press, use link:../keyboardrelease[Keyboard.release()] or link:../keyboardreleaseall[Keyboard.releaseAll()].
+When called, `Keyboard.press()` functions as if a key were pressed and held on your keyboard. Useful when using link:../keyboard/keyboardmodifiers[modifier keys]. To end the key press, use link:../keyboard/keyboardrelease[Keyboard.release()] or link:../keyboard/keyboardreleaseall[Keyboard.releaseAll()].
 
-It is necessary to call link:../keyboardbegin[Keyboard.begin()] before using `press()`.
+It is necessary to call link:../keyboard/keyboardbegin[Keyboard.begin()] before using `press()`.
 [%hardbreaks]
 
 

--- a/Language/Functions/USB/Keyboard/keyboardPrint.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPrint.adoc
@@ -16,7 +16,7 @@ title: Keyboard.print()
 === Description
 Sends a keystroke to a connected computer.
 
-`Keyboard.print()` must be called after initiating link:../keyboardbegin[Keyboard.begin()].
+`Keyboard.print()` must be called after initiating link:../keyboard/keyboardbegin[Keyboard.begin()].
 [%hardbreaks]
 
 

--- a/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
@@ -16,7 +16,7 @@ title: Keyboard.println()
 === Description
 Sends a keystroke to a connected computer, followed by a newline and carriage return.
 
-`Keyboard.println()` must be called after initiating link:../keyboardbegin[Keyboard.begin()].
+`Keyboard.println()` must be called after initiating link:../keyboard/keyboardbegin[Keyboard.begin()].
 [%hardbreaks]
 
 

--- a/Language/Functions/USB/Keyboard/keyboardRelease.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardRelease.adoc
@@ -14,7 +14,7 @@ title: Keyboard.release()
 
 [float]
 === Description
-Lets go of the specified key. See link:../keyboardpress[Keyboard.press()] for more information.
+Lets go of the specified key. See link:../keyboard/keyboardpress[Keyboard.press()] for more information.
 [%hardbreaks]
 
 

--- a/Language/Functions/USB/Keyboard/keyboardReleaseAll.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardReleaseAll.adoc
@@ -14,7 +14,7 @@ title: Keyboard.releaseAll()
 
 [float]
 === Description
-Lets go of all keys currently pressed. See link:../keyboardpress[Keyboard.press()] for additional information.
+Lets go of all keys currently pressed. See link:../keyboard/keyboardpress[Keyboard.press()] for additional information.
 [%hardbreaks]
 
 

--- a/Language/Functions/USB/Keyboard/keyboardWrite.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardWrite.adoc
@@ -14,7 +14,7 @@ title: Keyboard.write()
 
 [float]
 === Description
-Sends a keystroke to a connected computer. This is similar to pressing and releasing a key on your keyboard. You can send some ASCII characters or the additional link:../keyboardmodifiers[keyboard modifiers and special keys].
+Sends a keystroke to a connected computer. This is similar to pressing and releasing a key on your keyboard. You can send some ASCII characters or the additional link:../keyboard/keyboardmodifiers[keyboard modifiers and special keys].
 
 Only ASCII characters that are on the keyboard are supported. For example, ASCII 8 (backspace) would work, but ASCII 25 (Substitution) would not. When sending capital letters, `Keyboard.write()` sends a shift command plus the desired character, just as if typing on a keyboard. If sending a numeric type, it sends it as an ASCII character (ex. Keyboard.write(97) will send 'a').
 


### PR DESCRIPTION
The`/keyboard/...` part were missing in most of the URLs, leading to a dead end.