### PR TITLE
Update goto.adoc

### DIFF
--- a/Language/Structure/Control Structure/goto.adoc
+++ b/Language/Structure/Control Structure/goto.adoc
@@ -66,6 +66,8 @@ bailout:
 The use of `goto` is discouraged in C++ programming, and some authors of C++ programming books claim that the `goto` statement is never necessary, but used judiciously, it can simplify certain programs. The reason that many programmers frown upon the use of goto is that with the unrestrained use of `goto` statements, it is easy to create a program with undefined program flow, which can never be debugged.
 
 With that said, there are instances where a `goto` statement can come in handy, and simplify coding. One of these situations is to break out of deeply nested link:../for[for] loops, or link:../if[if] logic blocks, on a certain condition.
+
+It should be considered that - as opposed to functions - a "goto"-code can never return to its calling point. So instead of using the "goto"-control, it is advisable to "break" or "continue" the nested structures and define and call a function instead.
 [%hardbreaks]
 
 --


### PR DESCRIPTION
It should be considered that - as opposed to functions - a "goto"-code can never return to its calling point. So instead of using the "goto"-control, it is advisable to "break" or "continue" the nested structures and define and call a function instead.