### PR TITLE
Misusage of `strlen_p()`

### DIFF
--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -86,7 +86,8 @@ void setup() {
   Serial.println();
 
   // read back a char
-  for (byte k = 0; k < strlen_P(signMessage); k++) {
+  int signMessageLength = strlen_P(signMessage);
+  for (byte k = 0; k < signMessageLength; k++) {
     myChar = pgm_read_byte_near(signMessage + k);
     Serial.print(myChar);
   }


### PR DESCRIPTION
There is no actual reason to put a method that counts characters inside a `for-loop`, such that every iteration will reevaluate the length of `signMessage`.