### PR TITLE
Document limitation of Serial1.begin() config value for Nano 33 BLE boards

### DIFF
--- a/Language/Functions/Communication/Serial/begin.adoc
+++ b/Language/Functions/Communication/Serial/begin.adoc
@@ -113,6 +113,8 @@ Thanks to Jeff Gray for the mega example
 [float]
 === Notes and Warnings
 For USB CDC serial ports (e.g. `Serial` on the Leonardo), `Serial.begin()` is irrelevant. You can use any baud rate and configuration for serial communication with these ports. See the list of available serial ports for each board on the link:../../serial[Serial main page].
+
+The only `config` value supported for `Serial1` on the Arduino Nano 33 BLE and Nano 33 BLE Sense boards is `SERIAL_8N1`.
 [%hardbreaks]
 
 --


### PR DESCRIPTION
Add a warning that use of any `Serial1.begin()` config value other than `SERIAL_8N1` on the Arduino Nano 33
BLE boards will cause an Mbed OS crash.

Reference: https://github.com/arduino/ArduinoCore-mbed/issues/60#issuecomment-698436127

---
**NOTE:** Work is in progress to lift this limitation: https://github.com/ARMmbed/mbed-os/issues/13665. Once that fix has been made, pulled into `arduino-beta:mbed` boards platform, and a release of that boards platform made with the fix, this commit should be reverted.