### PR TITLE
analogReference now supported by Arduino nRF528x

### DIFF
--- a/Language/Functions/Analog IO/analogReference.adoc
+++ b/Language/Functions/Analog IO/analogReference.adoc
@@ -52,7 +52,7 @@ Arduino SAM Boards (Due)
 
 * AR_DEFAULT: the default analog reference of 3.3V. This is the only supported option for the Due.
 
-Arduino mbed-enabled Boards (Nano 33 BLE only): only available when using the _Arduino mbed-enabled Boards_ platform, and not when using the _Arduino nRF528x Boards (Mbed OS)_ platform
+Arduino mbed-enabled Boards (Nano 33 BLE only): available when using the _Arduino mbed-enabled Boards_ platform, or the _Arduino nRF528x Boards (Mbed OS)_ platform version 1.1.6 or later
 
 * AR_VDD: the default 3.3 V reference
 * AR_INTERNAL: built-in 0.6 V reference


### PR DESCRIPTION
In addition to the "Arduino mbed-enabled Boards" platform, this function is now also supported by the "Arduino nRF528x Boards (Mbed OS)" platform since version 1.1.6. 

https://github.com/arduino/ArduinoCore-nRF528x-mbedos/pull/81

This was previously discussed in #757.