### PR TITLE
Replace "B..." binary constants with "0b..."

### DIFF
--- a/Language/Structure/Bitwise Operators/bitwiseAnd.adoc
+++ b/Language/Structure/Bitwise Operators/bitwiseAnd.adoc
@@ -58,7 +58,7 @@ One of the most common uses of bitwise AND is to select a particular bit (or bit
 
 [source,arduino]
 ----
-PORTD = PORTD & B00000011;  // clear out bits 2 - 7, leave pins PD0 and PD1 untouched (xx & 11 == xx)
+PORTD = PORTD & 0b00000011;  // clear out bits 2 - 7, leave pins PD0 and PD1 untouched (xx & 11 == xx)
 ----
 
 --

--- a/Language/Structure/Bitwise Operators/bitwiseOr.adoc
+++ b/Language/Structure/Bitwise Operators/bitwiseOr.adoc
@@ -56,7 +56,7 @@ One of the most common uses of the Bitwise OR is to set multiple bits in a bit-p
 // Note: This code is AVR architecture specific
 // set direction bits for pins 2 to 7, leave PD0 and PD1 untouched (xx | 00 == xx)
 // same as pinMode(pin, OUTPUT) for pins 2 to 7 on Uno or Nano
-DDRD = DDRD | B11111100;
+DDRD = DDRD | 0b11111100;
 ----
 
 --

--- a/Language/Structure/Bitwise Operators/bitwiseXor.adoc
+++ b/Language/Structure/Bitwise Operators/bitwiseXor.adoc
@@ -56,12 +56,12 @@ The ^ operator is often used to toggle (i.e. change from 0 to 1, or 1 to 0) some
 // Note: This code uses registers specific to AVR microcontrollers (Uno, Nano, Leonardo, Mega, etc.)
 // it will not compile for other architectures
 void setup() {
-  DDRB = DDRB | B00100000;  // set PB5 (pin 13 on Uno/Nano, pin 9 on Leonardo/Micro, pin 11 on Mega) as OUTPUT
+  DDRB = DDRB | 0b00100000;  // set PB5 (pin 13 on Uno/Nano, pin 9 on Leonardo/Micro, pin 11 on Mega) as OUTPUT
   Serial.begin(9600);
 }
 
 void loop() {
-  PORTB = PORTB ^ B00100000;  // invert PB5, leave others untouched
+  PORTB = PORTB ^ 0b00100000;  // invert PB5, leave others untouched
   delay(100);
 }
 ----

--- a/Language/Structure/Compound Operators/compoundBitwiseAnd.adoc
+++ b/Language/Structure/Compound Operators/compoundBitwiseAnd.adoc
@@ -54,22 +54,22 @@ Bits that are "bitwise ANDed" with 0 are cleared to 0 so, if myByte is a byte va
 
 [source,arduino]
 ----
-myByte & B00000000 = 0;
+myByte & 0b00000000 = 0;
 ----
 
 Bits that are "bitwise ANDed" with 1 are unchanged so,
 
 [source,arduino]
 ----
-myByte & B11111111 = myByte;
+myByte & 0b11111111 = myByte;
 ----
 [%hardbreaks]
 
 [float]
 === Notes and Warnings
-Because we are dealing with bits in a bitwise operator - it is convenient to use the binary formatter with constants. The numbers are still the same value in other representations, they are just not as easy to understand. Also, B00000000 is shown for clarity, but zero in any number format is zero (hmmm something philosophical there?)
+Because we are dealing with bits in a bitwise operator - it is convenient to use the binary formatter with constants. The numbers are still the same value in other representations, they are just not as easy to understand. Also, 0b00000000 is shown for clarity, but zero in any number format is zero (hmmm something philosophical there?)
 
-Consequently - to clear (set to zero) bits 0 & 1 of a variable, while leaving the rest of the variable unchanged, use the compound bitwise AND operator (&=) with the constant B11111100
+Consequently - to clear (set to zero) bits 0 & 1 of a variable, while leaving the rest of the variable unchanged, use the compound bitwise AND operator (&=) with the constant 0b11111100
 
    1  0  1  0  1  0  1  0    variable
    1  1  1  1  1  1  0  0    mask
@@ -93,8 +93,8 @@ So if:
 
 [source,arduino]
 ----
-myByte = B10101010;
-myByte &= B11111100;  // results in B10101000
+myByte = 0b10101010;
+myByte &= 0b11111100;  // results in 0b10101000
 ----
 
 [%hardbreaks]

--- a/Language/Structure/Compound Operators/compoundBitwiseOr.adoc
+++ b/Language/Structure/Compound Operators/compoundBitwiseOr.adoc
@@ -49,22 +49,22 @@ A review of the Bitwise OR `|` operator:
 Bits that are "bitwise ORed" with 0 are unchanged, so if myByte is a byte variable,
 [source,arduino]
 ----
-myByte | B00000000 = myByte;
+myByte | 0b00000000 = myByte;
 ----
 
 Bits that are "bitwise ORed" with 1 are set to 1 so:
 [source,arduino]
 ----
-myByte | B11111111 = B11111111;
+myByte | 0b11111111 = 0b11111111;
 ----
 [%hardbreaks]
 
 [float]
 === Notes and Warnings
-Because we are dealing with bits in a bitwise operator - it is convenient to use the binary formatter with constants. The numbers are still the same value in other representations, they are just not as easy to understand. Also, B00000000 is shown for clarity, but zero in any number format is zero.
+Because we are dealing with bits in a bitwise operator - it is convenient to use the binary formatter with constants. The numbers are still the same value in other representations, they are just not as easy to understand. Also, 0b00000000 is shown for clarity, but zero in any number format is zero.
 [%hardbreaks]
 
-Consequently - to set bits 0 & 1 of a variable, while leaving the rest of the variable unchanged, use the compound bitwise OR operator (|=) with the constant B00000011
+Consequently - to set bits 0 & 1 of a variable, while leaving the rest of the variable unchanged, use the compound bitwise OR operator (|=) with the constant 0b00000011
 
    1  0  1  0  1  0  1  0    variable
    0  0  0  0  0  0  1  1    mask
@@ -88,8 +88,8 @@ Here is the same representation with the variables bits replaced with the symbol
 So if:
 [source,arduino]
 ----
-myByte = B10101010;
-myByte |= B00000011 == B10101011;
+myByte = 0b10101010;
+myByte |= 0b00000011 == 0b10101011;
 ----
 
 --

--- a/Language/Structure/Compound Operators/compoundBitwiseXor.adoc
+++ b/Language/Structure/Compound Operators/compoundBitwiseXor.adoc
@@ -49,22 +49,22 @@ A review of the Bitwise XOR `^` operator:
 Bits that are "bitwise XORed" with 0 are left unchanged. So if myByte is a byte variable,
 [source,arduino]
 ----
-myByte ^ B00000000 = myByte;
+myByte ^ 0b00000000 = myByte;
 ----
 
 Bits that are "bitwise XORed" with 1 are toggled so:
 [source,arduino]
 ----
-myByte ^ B11111111 = ~myByte;
+myByte ^ 0b11111111 = ~myByte;
 ----
 [%hardbreaks]
 
 [float]
 === Notes and Warnings
-Because we are dealing with bits in a bitwise operator - it is convenient to use the binary formatter with constants. The numbers are still the same value in other representations, they are just not as easy to understand. Also, B00000000 is shown for clarity, but zero in any number format is zero.
+Because we are dealing with bits in a bitwise operator - it is convenient to use the binary formatter with constants. The numbers are still the same value in other representations, they are just not as easy to understand. Also, 0b00000000 is shown for clarity, but zero in any number format is zero.
 [%hardbreaks]
 
-Consequently - to toggle bits 0 & 1 of a variable, while leaving the rest of the variable unchanged, use the compound bitwise XOR operator (^=) with the constant B00000011
+Consequently - to toggle bits 0 & 1 of a variable, while leaving the rest of the variable unchanged, use the compound bitwise XOR operator (^=) with the constant 0b00000011
 
    1  0  1  0  1  0  1  0    variable
    0  0  0  0  0  0  1  1    mask
@@ -88,8 +88,8 @@ Here is the same representation with the variables bits replaced with the symbol
 So if:
 [source,arduino]
 ----
-myByte = B10101010;
-myByte ^= B00000011 == B10101001;
+myByte = 0b10101010;
+myByte ^= 0b00000011 == 0b10101001;
 ----
 
 --

--- a/Language/Variables/Constants/integerConstants.adoc
+++ b/Language/Variables/Constants/integerConstants.adoc
@@ -32,9 +32,9 @@ Normally, integer constants are treated as base 10 (decimal) integers, but speci
 |
 
 |2 (binary)
-|B1111011
-|leading 'B'
-|only works with 8 bit values (0 to 255)   characters 0&1 valid
+|0b1111011
+|leading "0b"
+|characters 0&1 valid
 
 |8 (octal)
 |0173
@@ -76,13 +76,7 @@ Only the characters 0 and 1 are valid.
 === Example  Code:
 [source,arduino]
 ----
-n = B101; // same as 5 decimal ((1 * 2^2) + (0 * 2^1) + 1)
-----
-
-The binary formatter only works on bytes (8 bits) between 0 (B0) and 255 (B11111111). If it is convenient to input an int (16 bits) in binary form you can do it a two-step procedure such as:
-[source,arduino]
-----
-myInt = (B11001100 * 256) + B10101010;  // B11001100 is the high byte`
+n = 0b101; // same as 5 decimal ((1 * 2^2) + (0 * 2^1) + 1)
 ----
 [%hardbreaks]
 


### PR DESCRIPTION
Follow-up to issue arduino/Arduino#3561 and PR arduino/Arduino#7064 -- updating documentation to reflect this change.

Replaced all references to the deprecated `B...` binary format (e.g. `B00101010`) with the GCC- and C++14-compliant `0b...` format (e.g. `0b00101010`).
This also removes the restriction that binary constants must be 8 bits or less, so I'm removing that part as well.

Some examples using `B...` still remain in legacy code (libraries, old tutorials, etc); those should be replaced as well.