### PR TITLE
Update millis.adoc

### DIFF
--- a/Language/Functions/Time/millis.adoc
+++ b/Language/Functions/Time/millis.adoc
@@ -47,16 +47,16 @@ This example code prints on the serial port the number of milliseconds passed si
 
 [source,arduino]
 ----
-unsigned long my_time;
+unsigned long myTime;
 
 void setup() {
   Serial.begin(9600);
 }
 void loop() {
   Serial.print("Time: ");
-  my_time = millis();
+  myTime = millis();
 
-  Serial.println(my_time); //prints time since program started
+  Serial.println(myTime); //prints time since program started
   delay(1000);          // wait a second so as not to send massive amounts of data
 }
 ----

--- a/Language/Functions/Time/millis.adoc
+++ b/Language/Functions/Time/millis.adoc
@@ -47,16 +47,16 @@ This example code prints on the serial port the number of milliseconds passed si
 
 [source,arduino]
 ----
-unsigned long time;
+unsigned long my_time;
 
 void setup() {
   Serial.begin(9600);
 }
 void loop() {
   Serial.print("Time: ");
-  time = millis();
+  my_time = millis();
 
-  Serial.println(time); //prints time since program started
+  Serial.println(my_time); //prints time since program started
   delay(1000);          // wait a second so as not to send massive amounts of data
 }
 ----


### PR DESCRIPTION
changed variable named "time" to "my_time", because it was a conflict when compiling on ESP32 board; 
And it is not a good practice to define such generic variables that could be used in system variables. 
Using user variables like my_time and my_temp_sensor is much easier to understand for beginners and more intuitive, easier to differentiate from the system variables.