### PR TITLE
Add example and notes and warnings sections

### DIFF
--- a/Language/Functions/Communication/Serial/readString.adoc
+++ b/Language/Functions/Communication/Serial/readString.adoc
@@ -55,7 +55,7 @@ void setup() {
 
 void loop() {
   Serial.println("Enter data:");
-  while(Serial.available()==0); //wait for data available
+  while (Serial.available() == 0) {}     //wait for data available
   String teststr = Serial.readString(); //read until timeout
   teststr.trim(); // remove any \r \n whitespace at the end of the String
   if(teststr=="red") {

--- a/Language/Functions/Communication/Serial/readString.adoc
+++ b/Language/Functions/Communication/Serial/readString.adoc
@@ -34,8 +34,47 @@ title: Serial.readString()
 === Returns
 A `String` read from the serial buffer
 
+
 --
 // OVERVIEW SECTION ENDS
+
+
+// HOW TO USE SECTION STARTS
+[#howtouse]
+--
+
+[float]
+=== Example Code
+Demonstrate Serial.readString()
+
+[source,arduino]
+----
+void setup() {
+  Serial.begin(9600);
+}
+
+void loop() {
+  Serial.println("Enter data:");
+  while(Serial.available()==0); //wait for data available
+  String teststr = Serial.readString(); //read until timeout
+  teststr.trim(); // remove any \r \n whitespace at the end of the String
+  if(teststr=="red") {
+    Serial.println("A primary color");
+  } else {
+    Serial.println("Something else");
+  }
+}
+----
+[%hardbreaks]
+
+
+[float]
+=== Notes and Warnings
+The function does not terminate early because of end of line characters and the returned String may contain carriage return and/or line feed characters if they were received.
+[%hardbreaks]
+
+--
+// HOW TO USE SECTION ENDS
 
 
 // SEE ALSO SECTION

--- a/Language/Functions/Communication/Serial/readString.adoc
+++ b/Language/Functions/Communication/Serial/readString.adoc
@@ -56,9 +56,9 @@ void setup() {
 void loop() {
   Serial.println("Enter data:");
   while (Serial.available() == 0) {}     //wait for data available
-  String teststr = Serial.readString(); //read until timeout
-  teststr.trim(); // remove any \r \n whitespace at the end of the String
-  if(teststr=="red") {
+  String teststr = Serial.readString();  //read until timeout
+  teststr.trim();                        // remove any \r \n whitespace at the end of the String
+  if (teststr == "red") {
     Serial.println("A primary color");
   } else {
     Serial.println("Something else");

--- a/Language/Functions/Communication/Serial/readString.adoc
+++ b/Language/Functions/Communication/Serial/readString.adoc
@@ -70,7 +70,7 @@ void loop() {
 
 [float]
 === Notes and Warnings
-The function does not terminate early because of end of line characters and the returned String may contain carriage return and/or line feed characters if they were received.
+The function does not terminate early if the data contains end of line characters. The returned `String` may contain carriage return and/or line feed characters if they were received.
 [%hardbreaks]
 
 --


### PR DESCRIPTION
A very common mistake seen in forums is not expecting readString return value to have invisible \r \n characters. Many examples on the web do not explain to set serial terminal to "No line ending" so the user is unable to understand why they do not work.