### PR TITLE
Update stringObject.adoc

### DIFF
--- a/Language/Variables/Data Types/stringObject.adoc
+++ b/Language/Variables/Data Types/stringObject.adoc
@@ -128,6 +128,7 @@ String stringOne = String(5.698, 3);                  // using a float and the d
 === Operators
 
 [role="language"]
+* #LANGUAGE# link:../string/operators/assignment[= (assignment)]
 * #LANGUAGE# link:../string/operators/elementaccess[[\] (element access)]
 * #LANGUAGE# link:../string/operators/concatenation[+ (concatenation)]
 * #LANGUAGE# link:../string/operators/append[+= (append)]


### PR DESCRIPTION
The reference page shows that various initialization options are available as constructor parameters, but it does not show that existing String objects may  also be assigned a new value, and it does not describe what types can be assigned to an existing String object.