### PR TITLE
Added see also section for math functions

### DIFF
--- a/Language/Functions/Math/abs.adoc
+++ b/Language/Functions/Math/abs.adoc
@@ -72,5 +72,10 @@ a++;  // keep other math outside the function
 [float]
 === See also
 
+[role="language"]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/map/[map()]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/min/[min()]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/max/[max()]
+
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/constrain.adoc
+++ b/Language/Functions/Math/constrain.adoc
@@ -88,5 +88,10 @@ int constrainedInput = constrain(input, minimumValue, maximumValue);
 [float]
 === See also
 
+[role="language"]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/map/[map()]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/min/[min()]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/max/[max()]
+
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/map.adoc
+++ b/Language/Functions/Math/map.adoc
@@ -109,5 +109,9 @@ As previously mentioned, the map() function uses integer math. So fractions migh
 [float]
 === See also
 
+[role="language"]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/min/[min()]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/max/[max()]
+
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/max.adoc
+++ b/Language/Functions/Math/max.adoc
@@ -83,5 +83,9 @@ a--;  // keep other math outside the function
 [float]
 === See also
 
+[role="language"]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/map/[map()]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/min/[min()]
+
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/min.adoc
+++ b/Language/Functions/Math/min.adoc
@@ -82,5 +82,9 @@ a++;  // use this instead - keep other math outside the function
 [float]
 === See also
 
+[role="language"]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/map/[map()]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/max/[max()]
+
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/sq.adoc
+++ b/Language/Functions/Math/sq.adoc
@@ -72,5 +72,10 @@ int inputSquared = sq(input);
 [float]
 === See also
 
+[role="language"]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/map/[map()]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/min/[min()]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/max/[max()]
+
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/sqrt.adoc
+++ b/Language/Functions/Math/sqrt.adoc
@@ -46,5 +46,10 @@ The number's square root. Data type: `double`.
 [float]
 === See also
 
+[role="language"]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/map/[map()]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/min/[min()]
+* #LANGUAGE# https://arduino.cc/reference/en/language/functions/math/max/[max()]
+
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
The math functions in the language reference were lacking "see also" alternatives. Created some links to other relevant math functions, e.g. min, max and map.