### PR TITLE
[Documentation] Missing data type

### DIFF
--- a/Language/Variables/Constants/floatingPointConstants.adoc
+++ b/Language/Variables/Constants/floatingPointConstants.adoc
@@ -34,7 +34,7 @@ Similar to integer constants, floating point constants are used to make code mor
 
 [source,arduino]
 ----
-n = 0.005;  // 0.005 is a floating point constant
+const float n = 0.005;  // 0.005 is a floating point constant
 ----
 [%hardbreaks]
 

--- a/Language/Variables/Constants/floatingPointConstants.adoc
+++ b/Language/Variables/Constants/floatingPointConstants.adoc
@@ -34,7 +34,7 @@ Similar to integer constants, floating point constants are used to make code mor
 
 [source,arduino]
 ----
-const float n = 0.005;  // 0.005 is a floating point constant
+float n = 0.005;  // 0.005 is a floating point constant
 ----
 [%hardbreaks]
 


### PR DESCRIPTION
In the documentation of Floating Point I noticed  this example:

```c++
n = 0.005;  // 0.005 is a floating point constant
```
This code simply won't compile and get this error :   
'n' does not name a type

so this Line should be : 

```c++
const float n = 0.005;  // 0.005 is a floating point constant
```
Although this error may seem trivial for some professionals , but I think it seems misleading to newcomers.