### PR TITLE
Specify behavior of analogWrite on Nano 33 BLE/BLE Sense

### DIFF
--- a/Language/Functions/Analog IO/analogWrite.adoc
+++ b/Language/Functions/Analog IO/analogWrite.adoc
@@ -25,16 +25,17 @@ Writes an analog value (http://arduino.cc/en/Tutorial/PWM[PWM wave]) to a pin. C
 | Mega                      | 2 - 13, 44 - 46                | 490 Hz (pins 4 and 13: 980 Hz)
 | Leonardo, Micro, Yún      | 3, 5, 6, 9, 10, 11, 13         | 490 Hz (pins 3 and 11: 980 Hz)
 | Uno WiFi Rev2, Nano Every | 3, 5, 6, 9, 10                 | 976 Hz
-| MKR boards *              | 0 - 8, 10, A3, A4              | 732 Hz
-| MKR1000 WiFi *            | 0 - 8, 10, 11, A3, A4          | 732 Hz
-| Zero *                    | 3 - 13, A0, A1                 | 732 Hz
-| Nano 33 IoT *             | 2, 3, 5, 6, 9 - 12, A2, A3, A5 | 732 Hz
-| Nano 33 BLE/BLE Sense     | 1 - 13, A0 - A7                | 500 Hz
-| Due **                    | 2-13                           | 1000 Hz
+| MKR boards ¹              | 0 - 8, 10, A3, A4              | 732 Hz
+| MKR1000 WiFi ¹            | 0 - 8, 10, 11, A3, A4          | 732 Hz
+| Zero ¹                    | 3 - 13, A0, A1                 | 732 Hz
+| Nano 33 IoT ¹             | 2, 3, 5, 6, 9 - 12, A2, A3, A5 | 732 Hz
+| Nano 33 BLE/BLE Sense ²   | 1 - 13, A0 - A7                | 500 Hz
+| Due ³                     | 2-13                           | 1000 Hz
 | 101                       | 3, 5, 6, 9                     | pins 3 and 9: 490 Hz, pins 5 and 6: 980 Hz
 |========================================================================================================
-{empty}* In addition to PWM capabilities on the pins noted above, the MKR, Nano 33 IoT, and Zero boards have true analog output when using `analogWrite()` on the `DAC0` (`A0`) pin. +
-{empty}** In addition to PWM capabilities on the pins noted above, the Due has true analog output when using `analogWrite()` on pins `DAC0` and `DAC1`.
+{empty}¹ In addition to PWM capabilities on the pins noted above, the MKR, Nano 33 IoT, and Zero boards have true analog output when using `analogWrite()` on the `DAC0` (`A0`) pin. +
+{empty}² Only 4 different pins can be used at the same time. Enabling PWM on more than 4 pins will abort the running sketch and require resetting the board to upload a new sketch again. +
+{empty}³ In addition to PWM capabilities on the pins noted above, the Due has true analog output when using `analogWrite()` on pins `DAC0` and `DAC1`.
 
 [%hardbreaks]
 


### PR DESCRIPTION
After working with the Arduino Nano 33 BLE, I discovered that calling `analogWrite` on more than 4 pins will lock up the board. This is confirmed by https://forum.arduino.cc/t/arduino-nano-33-ble-damaged/639669/2.

I think the reference documentation should include this quirk since it's currently not documented anywhere, and might be confusing for Nano 33 BLE/BLE Sense board users.

I did replace footnote asterisks with superscript one, two and three since otherwise it would understand *** as bold formatting. I don't know if there is another way this could be done.