### PR TITLE
Update ifSerial.adoc

### DIFF
--- a/Language/Functions/Communication/Serial/ifSerial.adoc
+++ b/Language/Functions/Communication/Serial/ifSerial.adoc
@@ -36,6 +36,11 @@ None
 === Returns
 Returns true if the specified serial port is available. This will only return false if querying the Leonardo's USB CDC serial connection before it is ready. Data type: `bool`.
 
+
+[float]
+=== Warning
+This function adds a delay of 10ms in an attempt to solve "open but not quite" situations. Don't use it in tight loops.
+
 --
 // OVERVIEW SECTION ENDS
 


### PR DESCRIPTION
I got bitten by this delay in a loop that otherwise would easily keep up with interrupts. I think users should be aware of it! One would not expect such a line status return to take any time at all.