### PR TITLE
Add 'Signature' section to String.length() doc

### DIFF
--- a/Language/Variables/Data Types/String/Functions/length.adoc
+++ b/Language/Variables/Data Types/String/Functions/length.adoc
@@ -36,6 +36,10 @@ Returns the length of the String, in characters. (Note that this doesn't include
 === Returns
 The length of the String in characters.
 
+[float]
+=== Signature
+(in arduino/avr/cores/arduino/WString.h)
+inline unsigned int length(void) const;
 --
 // OVERVIEW SECTION ENDS
 


### PR DESCRIPTION
I just got failing unit tests, as it didn't like comparing integer literals and unsigned integers. 
Knowing where to find the definitions is useful, too. 
Other methods, and indeed all classes and functions, should adopt a similar philosophy.