### PR TITLE
Update bitshiftRight.adoc

### DIFF
--- a/Language/Structure/Bitwise Operators/bitshiftRight.adoc
+++ b/Language/Structure/Bitwise Operators/bitshiftRight.adoc
@@ -69,12 +69,19 @@ int x = -16;  // binary: 1111111111110000
 int y = 3;
 int result = (unsigned int)x >> y;  // binary: 0001111111111110
 ----
-If you are careful to avoid sign extension, you can use the right-shift operator `>>` as a way to divide by powers of 2. For example:
+Sign extension causes that you can use the right-shift operator `>>` as a way to divide by powers of 2, even negative numbers. For example:
 
 [source,arduino]
 ----
-int x = 1000;
-int y = x >> 3; // integer division of 1000 by 8, causing y = 125.
+int x = -1000;
+int y = x >> 3; // integer division of -1000 by 8, causing y = -125.
+----
+But be aware of the rounding with negative numbers:
+[source,arduino]
+----
+int x = -1001;
+int y = x >> 3; // division by shifting always rounds down, causing y = -126
+int z = x / 8;  // division operator rounds towards zero, causing z = -125
 ----
 
 --


### PR DESCRIPTION
Sign extension doesn't need to be avoided for arithmetic use of bit shifting, it actually causes that negative numbers are calculated correctly. Just the rounding is different compared to the division operator.