### PR TITLE
fixed typo (missing comma and space)

### DIFF
--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -67,7 +67,7 @@ Nothing
 
 `serialEvent()` and `serialEvent1()` don't work on the Arduino SAMD Boards
 
-`serialEvent()`, `serialEvent1()``serialEvent2()`, and `serialEvent3()`  don't work on the Arduino Due.
+`serialEvent()`, `serialEvent1()`, `serialEvent2()`, and `serialEvent3()`  don't work on the Arduino Due.
 [%hardbreaks]
 
 --


### PR DESCRIPTION
I noticed a tiny typo in the serialEvent reference page.

Thanks, Arduino team for all your work!