### PR TITLE
Remove redundant unit from definition of HIGH level

### DIFF
--- a/Language/Variables/Constants/constants.adoc
+++ b/Language/Variables/Constants/constants.adoc
@@ -41,7 +41,7 @@ When reading or writing to a digital pin there are only two possible values a pi
 The meaning of `HIGH` (in reference to a pin) is somewhat different depending on whether a pin is set to an `INPUT` or `OUTPUT`. When a pin is configured as an `INPUT` with `link:../../../functions/digital-io/pinmode[pinMode()]`, and read with `link:../../../functions/digital-io/digitalread[digitalRead()]`, the Arduino (ATmega) will report `HIGH` if:
 
   - a voltage greater than 3.0V is present at the pin (5V boards)
-  - a voltage greater than 2.0V volts is present at the pin (3.3V boards)
+  - a voltage greater than 2.0V is present at the pin (3.3V boards)
 [%hardbreaks]
 
 A pin may also be configured as an INPUT with link:../../../functions/digital-io/pinmode[`pinMode()`], and subsequently made HIGH with `link:../../../functions/digital-io/digitalwrite[digitalWrite()]`. This will enable the internal 20K pullup resistors, which will _pull up_ the input pin to a `HIGH` reading unless it is pulled `LOW` by external circuitry. This can be done alternatively by passing `INPUT_PULLUP` as argument to the link:../../../functions/digital-io/pinmode[`pinMode()`] function, as explained in more detail in the section "Defining Digital Pins modes: INPUT, INPUT_PULLUP, and OUTPUT" further below.


### PR DESCRIPTION
The text contained both the symbol and name of the unit consecutively.