### PR TITLE
Update analogReference for Mbed OS Boards

### DIFF
--- a/Language/Functions/Analog IO/analogReference.adoc
+++ b/Language/Functions/Analog IO/analogReference.adoc
@@ -52,7 +52,7 @@ Arduino SAM Boards (Due)
 
 * AR_DEFAULT: the default analog reference of 3.3V. This is the only supported option for the Due.
 
-Arduino Mbed OS Boards (Nano 33 BLE, Edge Control)
+Arduino Mbed OS Nano Boards (Nano 33 BLE), Arduino Mbed OS Edge Boards (Edge Control)
 
 * AR_VDD: the default 3.3 V reference
 * AR_INTERNAL: built-in 0.6 V reference

--- a/Language/Functions/Analog IO/analogReference.adoc
+++ b/Language/Functions/Analog IO/analogReference.adoc
@@ -52,7 +52,7 @@ Arduino SAM Boards (Due)
 
 * AR_DEFAULT: the default analog reference of 3.3V. This is the only supported option for the Due.
 
-Arduino mbed-enabled Boards (Nano 33 BLE only): available when using the _Arduino mbed-enabled Boards_ platform, or the _Arduino nRF528x Boards (Mbed OS)_ platform version 1.1.6 or later
+Arduino Mbed OS Boards (Nano 33 BLE, Edge Control)
 
 * AR_VDD: the default 3.3 V reference
 * AR_INTERNAL: built-in 0.6 V reference


### PR DESCRIPTION
The Mbed board platforms have been renamed and reorganized and the two previously named platforms (_Arduino mbed-enabled Boards_ and _Arduino nRF528x Boards (Mbed OS)_) no longer exist.

For the current platforms, the [Nano 33 BLE](https://github.com/arduino/ArduinoCore-mbed/blob/master/variants/ARDUINO_NANO33BLE/pins_arduino.h#L13) and [Edge Control](https://github.com/arduino/ArduinoCore-mbed/blob/master/variants/EDGE_CONTROL/pins_arduino.h#L13) share the same analog references. It also seems that the other Mbed OS boards do not have a selectable analog reference. 