### PR TITLE
Make array size match array literal size

### DIFF
--- a/Language/Variables/Data Types/array.adoc
+++ b/Language/Variables/Data Types/array.adoc
@@ -21,7 +21,7 @@ All of the methods below are valid ways to create (declare) an array.
 ----
   int myInts[6];
   int myPins[] = {2, 4, 8, 3, 6};
-  int mySensVals[6] = {2, 4, -8, 3, 2};
+  int mySensVals[5] = {2, 4, -8, 3, 2};
   char message[6] = "hello";
 ----
 You can declare an array without initializing it as in myInts.


### PR DESCRIPTION
## The problem

Currently, one of the sample lines of code in the `array` documentation declares an array of size 6, but assigns it a value of an array literal whose length is 5:

```c
// the length of the literal is 5, but the declared length is 6
int mySensVals[6] = {2, 4, -8, 3, 2}; 
```

This discrepancy has been confusing to me and my students, and may also result in undefined compiler behavior. (I'm not an expert on the Arduino-C compiler, but depending on how it resolves this statement it may result in an array of size 6 whose last element is garbage and/or whatever happened to be at that memory address.)

## My suggestion

Make the declaration be for an array of size 5 (instead of size 6). This solution keeps much of the documentation the same, changing only the declared array size.