### PR TITLE
Multiple fixes in Keyboard.{print,println}

### DIFF
--- a/Language/Functions/USB/Keyboard/keyboardPrint.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPrint.adoc
@@ -14,7 +14,7 @@ title: Keyboard.print()
 
 [float]
 === Description
-Sends a keystroke to a connected computer.
+Sends one or more keystrokes to a connected computer.
 
 `Keyboard.print()` must be called after initiating link:../keyboardbegin[Keyboard.begin()].
 [%hardbreaks]
@@ -29,12 +29,12 @@ Sends a keystroke to a connected computer.
 [float]
 === Parameters
 `character`: a char or int to be sent to the computer as a keystroke. +
-`characters`: a string to be sent to the computer as a keystroke.
+`characters`: a string to be sent to the computer as keystrokes.
 
 
 [float]
 === Returns
-Number of bytes sent. Data type: `size_t`.
+Number of keystrokes sent. Data type: `size_t`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
@@ -23,7 +23,7 @@ Sends a keystroke to a connected computer, followed by a newline and carriage re
 [float]
 === Syntax
 `Keyboard.println()` +
-`Keyboard.println(character)`+
+`Keyboard.println(character)` +
 `Keyboard.println(characters)`
 
 

--- a/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
@@ -14,7 +14,7 @@ title: Keyboard.println()
 
 [float]
 === Description
-Sends a keystroke to a connected computer, followed by a newline and carriage return.
+Sends one or more keystrokes to a connected computer, followed by a newline and carriage return.
 
 `Keyboard.println()` must be called after initiating link:../keyboardbegin[Keyboard.begin()].
 [%hardbreaks]
@@ -30,12 +30,12 @@ Sends a keystroke to a connected computer, followed by a newline and carriage re
 [float]
 === Parameters
 `character`: a char or int to be sent to the computer as a keystroke, followed by newline and carriage return. +
-`characters`: a string to be sent to the computer as a keystroke, followed by a newline and carriage return.
+`characters`: a string to be sent to the computer as keystrokes, followed by a newline and carriage return.
 
 
 [float]
 === Returns
-Number of bytes sent. Data type: `size_t`.
+Number of keystrokes sent. Data type: `size_t`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPrintln.adoc
@@ -14,7 +14,7 @@ title: Keyboard.println()
 
 [float]
 === Description
-Sends one or more keystrokes to a connected computer, followed by a newline and carriage return.
+Sends one or more keystrokes to a connected computer, followed by a keystroke on the Enter key.
 
 `Keyboard.println()` must be called after initiating link:../keyboardbegin[Keyboard.begin()].
 [%hardbreaks]
@@ -29,8 +29,8 @@ Sends one or more keystrokes to a connected computer, followed by a newline and 
 
 [float]
 === Parameters
-`character`: a char or int to be sent to the computer as a keystroke, followed by newline and carriage return. +
-`characters`: a string to be sent to the computer as keystrokes, followed by a newline and carriage return.
+`character`: a char or int to be sent to the computer as a keystroke, followed by Enter. +
+`characters`: a string to be sent to the computer as keystrokes, followed by Enter.
 
 
 [float]


### PR DESCRIPTION
This pull request addresses multiple small issues in keyboardPrint.adoc and keyboardPrintln.adoc:

1. The syntax of `Keyboard.println()` is described as:

   ```c++
   Keyboard.println()
   Keyboard.println(character)+ Keyboard.println(characters)
   ```

   where the `+` operator was meant to be a hard line break.

2. The functions are described as “Sends a keystroke to a connected computer [...]” even though a string is actually sent as a series of keystrokes rather than a single one.

3. The functions are said to return the “Number of bytes sent”, although they return the number of keystrokes (two 8-byte reports are actually sent for each single keystroke).

4. `Keyboard.println()` is said to end the output by “a newline and carriage return”, whereas in reality it sends a press and a release of <kbd>Return</kbd>, more commonly known as <kbd>Enter</kbd>.

Regarding the last point, the current description of `println()` seems to imply that it sends the ASCII LF and CR characters, in that unconventional order. It should be noted that:

* the Keyboard library sends keystrokes, not characters
* there is no such thing as the “newline” or “carriage return” keys
* `println()` terminates the output by a single keystroke

Technically, it would be more correct to specify that it hits [the <kbd>Return</kbd> key][return]. However, most people use “Return” and “Enter” interchangeably, and [“Enter” seems more common and less confusing][enter].

[return]: https://en.wikipedia.org/wiki/Enter_key
[enter]: https://ux.stackexchange.com/questions/54461/should-i-use-the-name-enter-or-return-key