### PR TITLE
Document the layout parameter of Keyboard.begin()

### DIFF
--- a/Language/Functions/USB/Keyboard/keyboardBegin.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardBegin.adoc
@@ -20,12 +20,26 @@ When used with a Leonardo or Due board, `Keyboard.begin()` starts emulating a ke
 
 [float]
 === Syntax
-`Keyboard.begin()`
+`Keyboard.begin()` +
+`Keyboard.begin(layout)`
 
 
 [float]
 === Parameters
-None
+`layout`: the keyboard layout to use. This parameter is optional and defaults to `KeyboardLayout_en_US`.
+
+
+[float]
+=== Keyboard layouts
+Currently, the library supports the following national keyboard layouts:
+
+* `KeyboardLayout_de_DE`: Germany
+* `KeyboardLayout_en_US`: USA
+* `KeyboardLayout_es_ES`: Spain
+* `KeyboardLayout_fr_FR`: France
+* `KeyboardLayout_it_IT`: Italy
+
+Custom layouts can be created by copying and modifying an existing layout. See the instructions in the file KeyboardLayout.h.
 
 
 [float]

--- a/Language/Functions/USB/Keyboard/keyboardBegin.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardBegin.adoc
@@ -39,8 +39,6 @@ Currently, the library supports the following national keyboard layouts:
 * `KeyboardLayout_fr_FR`: France
 * `KeyboardLayout_it_IT`: Italy
 
-Custom layouts can be created by copying and modifying an existing layout. See the instructions in the file KeyboardLayout.h.
-
 
 [float]
 === Returns
@@ -81,6 +79,11 @@ void loop() {
   }
 }
 ----
+
+
+[float]
+=== Notes and Warnings
+Custom layouts can be created by copying and modifying an existing layout. See the instructions in the Keyboard library's KeyboardLayout.h file.
 
 --
 // HOW TO USE SECTION ENDS


### PR DESCRIPTION
Since release 1.0.3, the Keyboard library [supports international keyboard layouts][pr]. The requested layout is chosen via an optional parameter passed to `Keyboard.begin()`. This pull request documents this new feature of the library.

## Defining custom layouts

Users can define their own keyboard layouts, and give them to `Keyboard.begin()`. I am not sure about the best approach to document this feature though, and thus I would appreciate some feedback from the community.

The way to use an existing layout is very easy, and well suited to the target audience of beginners. Defining a custom layout, however, is more of a feature for advanced users, and it should be documented in a way that doesn't make the beginners feel overwhelmed.

My approach in this PR is to point the users to [the header file KeyboardLayout.h][header], which has extensive comments documenting the procedure. The assumption is that if someone is willing to look at a source file, he is presumably advanced enough to successfully define his own layout. This may not be the best approach though. Maybe add an extra document here with the information that is currently in that header file? In that case, should that document feature a warning like “this is for advanced users”? Maybe document also the way to contribute the layout back to the community?

[pr]: /arduino-libraries/Keyboard/pull/53
[header]: /arduino-libraries/Keyboard/blob/master/src/KeyboardLayout.h