### PR TITLE
Update compoundMultiplication.adoc

### DIFF
--- a/Language/Structure/Compound Operators/compoundMultiplication.adoc
+++ b/Language/Structure/Compound Operators/compoundMultiplication.adoc
@@ -47,7 +47,7 @@ This is a convenient shorthand to perform multiplication of a variable with anot
 [source,arduino]
 ----
 x = 2;
-x *= 2; // x now contains 4
+x *= 3; // x now contains 6
 ----
 
 


### PR DESCRIPTION
Change Example Code from:

x = 2;
x *= 2; // x now contains 4

----

Change it to:
x = 2;
x *= 3; // x now contains 6
----

Just makes it a little clearer, since 2+2=4 and 2*2=4. Too many twos.