### PR TITLE
Update PROGMEM.adoc

### DIFF
--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -151,7 +151,7 @@ void loop() {
 
 
   for (int i = 0; i < 6; i++) {
-    strcpy_P(buffer, (char *)pgm_read_word(&(string_table[i])));  // Necessary casts and dereferencing, just copy.
+    strcpy_P(buffer, (char *)pgm_read_ptr(&(string_table[i])));  // Necessary casts and dereferencing, just copy.
     Serial.println(buffer);
     delay(500);
   }


### PR DESCRIPTION
The use of pgm_read_word() in the example is wrong and only works on 16 bit systems. We are dealing with a pointer here so the correct function would be pgm_read_ptr().