### PR TITLE
update print.doc  -- rounding in case of floating point 

### DIFF
--- a/Language/Functions/Communication/Serial/print.adoc
+++ b/Language/Functions/Communication/Serial/print.adoc
@@ -30,7 +30,7 @@ An optional second parameter specifies the base (format) to use; permitted value
 * `_Serial_.print(78, HEX)` gives "4E" +
 * `_Serial_.print(1.23456, 0)` gives "1" +
 * `_Serial_.print(1.23456, 2)` gives "1.23" +
-* `_Serial_.print(1.23456, 4)` gives "1.2345"
+* `_Serial_.print(1.23456, 4)` gives "1.2346"
 
 You can pass flash-memory based strings to `_Serial_.print()` by wrapping them with link:../../../../variables/utilities/progmem[F()]. For example:
 


### PR DESCRIPTION
In case of floating-point and specify the number of decimal places, Serial.print() supports rounding.  0 to 4 then rounddown, 5 to 9 then round up.
so the original text
Serial.print(1.23456, 4) gives "1.2345"
should be:
Serial.print(1.23456, 4) gives "1.2346"

I checked the result  on TINKERCAD and update line is correct.