### PR TITLE
Fix misspellings in headings

### DIFF
--- a/Language/Functions/Communication/Wire/endTransmission.adoc
+++ b/Language/Functions/Communication/Wire/endTransmission.adoc
@@ -13,12 +13,12 @@ title: endTransmission()
 This function ends a transmission to a peripheral device that was begun by `beginTransmission()` and transmits the bytes that were queued by `write()`. As of Arduino 1.0.1, `endTransmission()` accepts a boolean argument changing its behavior for compatibility with certain I2C devices. If true, `endTransmission()` sends a stop message after transmission, releasing the I2C bus. If false, `endTransmission()` sends a restart message after transmission. The bus will not be released, which prevents another controller device from transmitting between messages. This allows one controller device to send multiple transmissions while in control. The default value is true.
 
 [float]
-=== Syntaxx
+=== Syntax
 `Wire.endTransmission()`
 `Wire.endTransmission(stop)`
 
 [float]
-=== Parameterss
+=== Parameters
 
 * _stop_: true or false. True will send a stop message, releasing the bus after transmission. False will send a restart, keeping the connection active.
 [float]


### PR DESCRIPTION
Headings fixed:
- "Syntax"
- "Parameters"