### PR TITLE
Fixed grammar mistake

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,7 +47,7 @@ reference-en
 │   ├── Functions
 │   ├── Structure
 │   └── Variables
-├── LICENCE.md
+├── LICENSE.md
 └── README.adoc
 
 ----


### PR DESCRIPTION
Grammar mistake at line 50: LICENCE.md
It should be LICENSE because the license name is LICENSE.md