### PR TITLE
Add missing function (endTransmission())

### DIFF
--- a/Language/Functions/Communication/Wire.adoc
+++ b/Language/Functions/Communication/Wire.adoc
@@ -62,6 +62,7 @@ link:../wire/begin[begin()] +
 link:../wire/end[end()] +
 link:../wire/requestfrom[requestFrom()] +
 link:../wire/begintransmission[beginTransmission()] +
+link:../wire/endtransmission[endTransmission()] +
 link:../wire/write[write()] +
 link:../wire/available[available()] +
 link:../wire/read[read()] +


### PR DESCRIPTION
endTransmission function page exists but link is missing from the function list on the Wire.h page.