### PR TITLE
Modification of Returns section

### DIFF
--- a/Language/Variables/Data Types/String/Functions/charAt.adoc
+++ b/Language/Variables/Data Types/String/Functions/charAt.adoc
@@ -35,7 +35,7 @@ Access a particular character of the String.
 
 [float]
 === Returns
-The n'th character of the String.
+The character at index n of the String.
 
 --
 // OVERVIEW SECTION ENDS


### PR DESCRIPTION
"The n’th character of the String" means the returned char is at index n+1 of the String, which is an incorrect description of the output.