### PR TITLE
Describe `noInterrupts` disabling USB handshakes

### DIFF
--- a/Language/Functions/Interrupts/noInterrupts.adoc
+++ b/Language/Functions/Interrupts/noInterrupts.adoc
@@ -66,9 +66,8 @@ void loop() {
 
 [float]
 === Notes and Warnings
-Note that disabling interrupts on the Arduino Nano 3.3v BLE will make the board
-not appear in the Ports tab, since this disables its ability to respond to USB
-handshakes (see  https://arduino.stackexchange.com/a/90045/83235[this answer^])
+Note that disabling interrupts on the Arduino boards with native USB capabilities (e.g., link:https://docs.arduino.cc/hardware/leonardo[Leonardo^]) will make the board
+not appear in the Port menu, since this disables its USB capability.
 
 --
 // HOW TO USE SECTION ENDS

--- a/Language/Functions/Interrupts/noInterrupts.adoc
+++ b/Language/Functions/Interrupts/noInterrupts.adoc
@@ -17,7 +17,7 @@ subCategories: [ "Interrupts" ]
 
 [float]
 === Description
-Disables interrupts (you can re-enable them with link:../interrupts[`interrupts()`]). Interrupts allow certain important tasks to happen in the background and are enabled by default. Some functions will not work while interrupts are disabled, and incoming communication may be ignored. Interrupts can slightly disrupt the timing of code, however, and may be disabled for particularly critical sections of code. Note that disabling interrupts on the Arduino Nano 3.3v BLE will make the board not appear in the Ports tab, since this disables its ability to respond to USB handshakes (see  https://arduino.stackexchange.com/a/90045/83235[this answer^])
+Disables interrupts (you can re-enable them with link:../interrupts[`interrupts()`]). Interrupts allow certain important tasks to happen in the background and are enabled by default. Some functions will not work while interrupts are disabled, and incoming communication may be ignored. Interrupts can slightly disrupt the timing of code, however, and may be disabled for particularly critical sections of code.
 [%hardbreaks]
 
 
@@ -61,6 +61,14 @@ void loop() {
   // other code here
 }
 ----
+[%hardbreaks]
+
+
+[float]
+=== Notes and Warnings
+Note that disabling interrupts on the Arduino Nano 3.3v BLE will make the board
+not appear in the Ports tab, since this disables its ability to respond to USB
+handshakes (see  https://arduino.stackexchange.com/a/90045/83235[this answer^])
 
 --
 // HOW TO USE SECTION ENDS

--- a/Language/Functions/Interrupts/noInterrupts.adoc
+++ b/Language/Functions/Interrupts/noInterrupts.adoc
@@ -17,7 +17,7 @@ subCategories: [ "Interrupts" ]
 
 [float]
 === Description
-Disables interrupts (you can re-enable them with `interrupts()`). Interrupts allow certain important tasks to happen in the background and are enabled by default. Some functions will not work while interrupts are disabled, and incoming communication may be ignored. Interrupts can slightly disrupt the timing of code, however, and may be disabled for particularly critical sections of code.
+Disables interrupts (you can re-enable them with link:../interrupts[`interrupts()`]). Interrupts allow certain important tasks to happen in the background and are enabled by default. Some functions will not work while interrupts are disabled, and incoming communication may be ignored. Interrupts can slightly disrupt the timing of code, however, and may be disabled for particularly critical sections of code. Note that disabling interrupts on the Arduino Nano 3.3v BLE will make the board not appear in the Ports tab, since this disables its ability to respond to USB handshakes (see  https://arduino.stackexchange.com/a/90045/83235[this answer^])
 [%hardbreaks]
 
 


### PR DESCRIPTION
See [this SO question and answer](https://arduino.stackexchange.com/questions/90043/nointerrupts-causes-the-arduino-to-no-longer-appear-in-ports)

This change updates the docs to describe how disabling interrupts on the Arduino Nano 3.3v BLE will make the board not appear in the Ports tab, since this disables its ability to respond to USB handshakes.