### PR TITLE
Updated the documentation of the trigonometry functions.

### DIFF
--- a/Language/Functions/Trigonometry/cos.adoc
+++ b/Language/Functions/Trigonometry/cos.adoc
@@ -28,7 +28,7 @@ Calculates the cosine of an angle (in radians). The result will be between -1 an
 
 [float]
 === Parameters
-`rad`: The angle in radians. Allowed data types: `float`.
+`rad`: The angle in radians. Allowed data types: `double`.
 
 
 [float]

--- a/Language/Functions/Trigonometry/sin.adoc
+++ b/Language/Functions/Trigonometry/sin.adoc
@@ -28,7 +28,7 @@ Calculates the sine of an angle (in radians). The result will be between -1 and 
 
 [float]
 === Parameters
-`rad`: The angle in radians. Allowed data types: `float`.
+`rad`: The angle in radians. Allowed data types: `double`.
 
 
 [float]

--- a/Language/Functions/Trigonometry/tan.adoc
+++ b/Language/Functions/Trigonometry/tan.adoc
@@ -28,7 +28,7 @@ Calculates the tangent of an angle (in radians). The result will be between nega
 
 [float]
 === Parameters
-`rad`: The angle in radians. Allowed data types: `float`.
+`rad`: The angle in radians. Allowed data types: `double`.
 
 
 [float]


### PR DESCRIPTION
All three functions have the following signature `double (*)(double)`. This is
now reflected in the documentation.