### PR TITLE
Adding null return for readStringUntil or equivalent for readBytesUntil

### DIFF
--- a/Language/Functions/Communication/Serial/readStringUntil.adoc
+++ b/Language/Functions/Communication/Serial/readStringUntil.adoc
@@ -33,7 +33,8 @@ title: Serial.readStringUntil()
 
 [float]
 === Returns
-The entire `String` read from the serial buffer, up to the terminator character
+The entire `String` read from the serial buffer, up to the terminator character.
+If the terminator character can't be found, or if there is no data before the terminator character, it will return `null`.
 
 --
 // OVERVIEW SECTION ENDS
@@ -46,6 +47,7 @@ The entire `String` read from the serial buffer, up to the terminator character
 [float]
 === Notes and Warnings
 The terminator character is discarded from the serial buffer.
+If the terminator character can't be found, all read characters will be discarded.
 [%hardbreaks]
 
 --

--- a/Language/Functions/Communication/Serial/readStringUntil.adoc
+++ b/Language/Functions/Communication/Serial/readStringUntil.adoc
@@ -34,7 +34,7 @@ title: Serial.readStringUntil()
 [float]
 === Returns
 The entire `String` read from the serial buffer, up to the terminator character.
-If the terminator character can't be found, or if there is no data before the terminator character, it will return `null`.
+If the terminator character can't be found, or if there is no data before the terminator character, it will return `NULL`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamReadBytesUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamReadBytesUntil.adoc
@@ -16,7 +16,7 @@ title: Stream.readBytesUntil()
 === Description
 `readBytesUntil()` reads characters from a stream into a buffer. The function terminates if the terminator character is detected, the determined length has been read, or it times out (see link:../streamsettimeout[setTimeout()]). The function returns the characters up to the last character before the supplied terminator. The terminator itself is not returned in the buffer.
 
-`readBytesUntil()` returns the number of bytes placed in the buffer. A 0 means no valid data was found.
+`readBytesUntil()` returns the number of bytes placed in the buffer. A 0 means the terminator character can't be found or there is no data before it.
 
 This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 [%hardbreaks]
@@ -37,7 +37,7 @@ This function is part of the Stream class, and can be called by any class that i
 
 [float]
 === Returns
-The number of bytes placed in the buffer.
+The number of bytes (excluding the terminator character) placed in the buffer if the terminator character has been found.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamReadStringUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamReadStringUntil.adoc
@@ -33,7 +33,8 @@ This function is part of the Stream class, and can be called by any class that i
 
 [float]
 === Returns
-The entire String read from a stream, up to the terminator character
+The entire String read from a stream, up to the terminator character.
+If the terminator character can't be found, or if there is no data before the terminator character, it will return `null`.
 
 --
 // OVERVIEW SECTION ENDS
@@ -46,6 +47,7 @@ The entire String read from a stream, up to the terminator character
 [float]
 === Notes and Warnings
 The terminator character is discarded from the stream.
+If the terminator character can't be found, all read characters will be discarded.
 [%hardbreaks]
 
 --

--- a/Language/Functions/Communication/Stream/streamReadStringUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamReadStringUntil.adoc
@@ -34,7 +34,7 @@ This function is part of the Stream class, and can be called by any class that i
 [float]
 === Returns
 The entire String read from a stream, up to the terminator character.
-If the terminator character can't be found, or if there is no data before the terminator character, it will return `null`.
+If the terminator character can't be found, or if there is no data before the terminator character, it will return `NULL`.
 
 --
 // OVERVIEW SECTION ENDS


### PR DESCRIPTION
The documentation doesn't talk about what is returned when readStringUntil can't find the terminator, so I added it.

I added clarification that if read*Until don't find ther terminator all read characters are discarded.

Also I documented that if a terminator is found (but without previous data) the code manage it has if there is no terminator. (About that, I created https://github.com/arduino/ArduinoCore-avr/issues/491. We should be able to know about the difference)
