### PR TITLE
Update write.adoc

### DIFF
--- a/Language/Functions/Communication/Wire/write.adoc
+++ b/Language/Functions/Communication/Wire/write.adoc
@@ -10,8 +10,7 @@ title: write()
 
 [float]
 === Description
-This function writes data from a peripheral device in response to a request from a controller device, or queues bytes for transmission from a controller to peripheral device (in-between calls to `beginTransmission()` and `endTransmission()`). 
-You can write a max 32 bytes at once to the tx buffer.
+This function writes data from a peripheral device in response to a request from a controller device, or queues bytes for transmission from a controller to peripheral device (in-between calls to `beginTransmission()` and `endTransmission()`).
 
 [float]
 === Syntax
@@ -25,6 +24,8 @@ You can write a max 32 bytes at once to the tx buffer.
 * _string_: a string to send as a series of bytes.
 * _data_: an array of data to send as bytes.
 * _length_: the number of bytes to transmit.
+
+be aware of the fact that you can't send more than 32 bytes at once due to the tx buffer limit in the library.
   
 [float]
 === Returns 

--- a/Language/Functions/Communication/Wire/write.adoc
+++ b/Language/Functions/Communication/Wire/write.adoc
@@ -10,7 +10,8 @@ title: write()
 
 [float]
 === Description
-This function writes data from a peripheral device in response to a request from a controller device, or queues bytes for transmission from a controller to peripheral device (in-between calls to `beginTransmission()` and `endTransmission()`). You can write max 32 bytes at once.
+This function writes data from a peripheral device in response to a request from a controller device, or queues bytes for transmission from a controller to peripheral device (in-between calls to `beginTransmission()` and `endTransmission()`). 
+You can write a max 32 bytes at once to the tx buffer.
 
 [float]
 === Syntax

--- a/Language/Functions/Communication/Wire/write.adoc
+++ b/Language/Functions/Communication/Wire/write.adoc
@@ -10,7 +10,7 @@ title: write()
 
 [float]
 === Description
-This function writes data from a peripheral device in response to a request from a controller device, or queues bytes for transmission from a controller to peripheral device (in-between calls to `beginTransmission()` and `endTransmission()`).
+This function writes data from a peripheral device in response to a request from a controller device, or queues bytes for transmission from a controller to peripheral device (in-between calls to `beginTransmission()` and `endTransmission()`). You can write max 32 bytes at once.
 
 [float]
 === Syntax


### PR DESCRIPTION
It is not stated that the library has a max buffer size of 32 bytes. Everything more than that is being discarded. I think it would be really nice to have that in the documentation.