### PR TITLE
Remove return value from Wire.clearWireTimeoutFlag() documentation.

### DIFF
--- a/Language/Functions/Communication/Wire/clearWireTimeoutFlag.adoc
+++ b/Language/Functions/Communication/Wire/clearWireTimeoutFlag.adoc
@@ -26,7 +26,7 @@ None.
 
 [float]
 === Returns
-* bool: The current value of the flag
+None.
 
 [float]
 === Portability Notes


### PR DESCRIPTION
I haven't been able to find any implementation of `Wire.clearWireTimeoutFlag()` with a return value, and looking at the original specification in https://github.com/arduino/reference-en/issues/895, it looks it is not meant to return anything.

So assuming this might have been a copy/paste error, this PR removes it.