### PR TITLE
keyboardBegin.adoc: add Portuguese keyboard layout

### DIFF
--- a/Language/Functions/USB/Keyboard/keyboardBegin.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardBegin.adoc
@@ -38,7 +38,9 @@ Currently, the library supports the following national keyboard layouts:
 * `KeyboardLayout_en_US`: USA
 * `KeyboardLayout_es_ES`: Spain
 * `KeyboardLayout_fr_FR`: France
+* `KeyboardLayout_hu_HU`: Hungary
 * `KeyboardLayout_it_IT`: Italy
+* `KeyboardLayout_pt_PT`: Portugal
 * `KeyboardLayout_sv_SE`: Sweden
 
 


### PR DESCRIPTION
Since [commit cbee538][co] ([pull request #77][pr], merged on 2023-02-20), [the Keyboard library][kbd] supports the Portuguese keyboard layout. This pull request adds the layout to the documentation of `Keyboard.begin()`.

**This is a draft pull request**. Since the latest release of the Keyboard library (1.0.4) does not include the Portuguese layout, this layout is only available on master. I will remove the “draft” status once the layout is available in a released version. Note that the commit message mentions release 1.0.5, which is the expected version number of the next release. If the version number turns out to be different (1.1.0 maybe?), I will amend the commit message.

[co]: /arduino-libraries/Keyboard/commit/cbee5385c7e798587574609dfae0e1a42cfdebf8
[pr]: /arduino-libraries/Keyboard/pull/77
[kbd]: /arduino-libraries/Keyboard