### PR TITLE
Update abs.adoc

### DIFF
--- a/Language/Functions/Math/abs.adoc
+++ b/Language/Functions/Math/abs.adoc
@@ -34,7 +34,7 @@ Calculates the absolute value of a number.
 [float]
 === Returns
 `x`: if x is greater than or equal to 0. +
-`-x`: if x is less than 0.
+`x`: if x is less than 0.
 
 --
 // OVERVIEW SECTION ENDS


### PR DESCRIPTION
just corrected a typing mistake.
i just tested example code and realized there is typing error in return part.
As its official documentation i think it should as accurate as possible.