### PR TITLE
Add new boards to attachInterrupt()

### DIFF
--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -21,6 +21,7 @@ The first parameter to `attachInterrupt()` is an interrupt number. Normally you 
 |===================================================
 |Board                             |Digital Pins Usable For Interrupts
 |Uno, Nano, Mini, other 328-based  |2, 3
+|UNO R4 Minima, UNO R4 WiFi        |2, 3
 |Uno WiFi Rev.2, Nano Every        |all digital pins
 |Mega, Mega2560, MegaADK           |2, 3, 18, 19, 20, 21 (*pins 20 & 21* are not available to use for interrupts while they are used for I2C communication)
 |Micro, Leonardo, other 32u4-based |0, 1, 2, 3, 7
@@ -28,6 +29,8 @@ The first parameter to `attachInterrupt()` is an interrupt number. Normally you 
 |MKR Family boards                 |0, 1, 4, 5, 6, 7, 8, 9, A1, A2
 |Nano 33 IoT                       |2, 3, 9, 10, 11, 13, A1, A5, A7
 |Nano 33 BLE, Nano 33 BLE Sense    |all pins
+|Nano RP2040 Connect               |all pins except A6/A7
+|Nano ESP32                        |all pins
 |Due                               |all digital pins
 |101                               |all digital pins (Only pins 2, 5, 7, 8, 10, 11, 12, 13 work with *CHANGE*)
 |===================================================

--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -31,6 +31,7 @@ The first parameter to `attachInterrupt()` is an interrupt number. Normally you 
 |Nano 33 BLE, Nano 33 BLE Sense    |all pins
 |Nano RP2040 Connect               |all pins except A6/A7
 |Nano ESP32                        |all pins
+|GIGA R1 WiFi                      |all pins
 |Due                               |all digital pins
 |101                               |all digital pins (Only pins 2, 5, 7, 8, 10, 11, 12, 13 work with *CHANGE*)
 |===================================================


### PR DESCRIPTION
Recent release of boards were not added to the `attachInterrupt()` reference.
- GIGA R1 WiFi
- Nano ESP32
- Nano RP2040 Connect
- UNO R4 WiFi & Minima