### PR TITLE
Remove false implications about PROGMEM

### DIFF
--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -17,16 +17,17 @@ subCategories: [ "Utilities" ]
 
 [float]
 === Description
-Store data in flash (program) memory instead of SRAM. There's a description of the various https://www.arduino.cc/en/Tutorial/Foundations/Memory[types of memory] available on an Arduino board.
+Keep constant data in flash (program) memory only, instead of copying it to SRAM when the program starts. There's a description of the various https://www.arduino.cc/en/Tutorial/Foundations/Memory[types of memory] available on an Arduino board.
 
-The `PROGMEM` keyword is a variable modifier, it should be used only with the datatypes defined in pgmspace.h. It tells the compiler "put this information into flash memory", instead of into SRAM, where it would normally go.
+The `PROGMEM` keyword is a variable modifier, it should be used only with the datatypes defined in pgmspace.h. It tells the compiler "keep this information in flash memory only", instead of copying it to SRAM at start up, like it would normally do.
 
 PROGMEM is part of the link:http://www.nongnu.org/avr-libc/user-manual/group\__avr__pgmspace.html[pgmspace.h] library. It is included automatically in modern versions of the IDE. However, if you are using an IDE version below 1.0 (2011), you'll first need to include the library at the top of your sketch, like this:
 
 `#include <avr/pgmspace.h>`
+
 While `PROGMEM` could be used on a single variable, it is really only worth the fuss if you have a larger block of data that needs to be stored, which is usually easiest in an array, (or another C++ data structure beyond our present discussion).
 
-Using `PROGMEM` is also a two-step procedure. After getting the data into Flash memory, it requires special methods (functions), also defined in the link:http://www.nongnu.org/avr-libc/user-manual/group\__avr__pgmspace.html[pgmspace.h] library, to read the data from program memory back into SRAM, so we can do something useful with it.
+Using `PROGMEM` is a two-step procedure. Once a variable has been defined with `PROGMEM`, it cannot be read like a regular SRAM-based variable: you have to read it using specific functions, also defined in link:http://www.nongnu.org/avr-libc/user-manual/group\__avr__pgmspace.html[pgmspace.h].
 [%hardbreaks]
 
 


### PR DESCRIPTION
This pull request addresses issue #739: PROGMEM.adoc falsely implies that `PROGMEM` costs flash space, and that reading `PROGMEM` data incurs the cost of an extra flash-to-SRAM copy.

Note that pull request #787 partially addressed the issue, but only fixed the section about the `F()` macro.