### PR TITLE
Update switch case supported data types

### DIFF
--- a/Language/Structure/Control Structure/switchCase.adoc
+++ b/Language/Structure/Control Structure/switchCase.adoc
@@ -44,9 +44,10 @@ switch (var) {
 
 [float]
 === Parameters
-`var`: a variable whose value to compare with various cases. Allowed data types: `int`, `char`. +
-`label1`, `label2`: constants. Allowed data types: `int`, `char`.
+`var`: an *integer* variable whose value to compare with various cases. Any integer data type is allowed*, such as `byte`, `char`, `int`, `long`.
+`label1`, `label2`: constants. Any integer data type here is also allowed.
 
+*You can also use the `bool` data type when you just two switch cases.
 
 [float]
 === Returns

--- a/Language/Structure/Control Structure/switchCase.adoc
+++ b/Language/Structure/Control Structure/switchCase.adoc
@@ -49,6 +49,8 @@ switch (var) {
 
 *You can also use the `bool` data type when you just two switch cases.
 
+Note that you can also negative values as input.
+
 [float]
 === Returns
 Nothing


### PR DESCRIPTION
Switch case had inaccurately listed only `int` and `char` as supported data types when using switch case. It supports in fact all integral types (byte to long), even bool. 

This PR updated the parameter section.