### PR TITLE
Update String.reserve()

### DIFF
--- a/Language/Variables/Data Types/String/Functions/reserve.adoc
+++ b/Language/Variables/Data Types/String/Functions/reserve.adoc
@@ -35,7 +35,7 @@ The String reserve() function allows you to allocate a buffer in memory for mani
 
 [float]
 === Returns
-Nothing
+`1` on success, `0` on failure.
 
 --
 // OVERVIEW SECTION ENDS


### PR DESCRIPTION
The documentation for the `reserve()` function stated that nothing is returned. This is not true, as it will return either a `1` on success and `0` on failure.