### PR TITLE
Remove old version mentions

### DIFF
--- a/Language/Functions/Communication/Serial/flush.adoc
+++ b/Language/Functions/Communication/Serial/flush.adoc
@@ -14,7 +14,7 @@ title: Serial.flush()
 
 [float]
 === Description
-Waits for the transmission of outgoing serial data to complete. (Prior to Arduino 1.0, this instead removed any buffered incoming serial data.)
+Waits for the transmission of outgoing serial data to complete.
 
 `flush()` inherits from the link:../../stream/streamflush[Stream] utility class.
 [%hardbreaks]

--- a/Language/Functions/Communication/Serial/ifSerial.adoc
+++ b/Language/Functions/Communication/Serial/ifSerial.adoc
@@ -18,7 +18,6 @@ Indicates if the specified Serial port is ready.
 
 On the boards with native USB, `if (Serial)` (or `if(SerialUSB)` on the Due) indicates whether or not the USB CDC serial connection is open. For all other boards, and the non-USB CDC ports, this will always return true.
 
-This was introduced in Arduino IDE 1.0.1.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Serial/write.adoc
+++ b/Language/Functions/Communication/Serial/write.adoc
@@ -65,7 +65,7 @@ void loop() {
 
 [float]
 === Notes and Warnings
-As of Arduino IDE 1.0, serial transmission is asynchronous. If there is enough empty space in the transmit buffer, `Serial.write()` will return before any characters are transmitted over serial. If the transmit buffer is full then `Serial.write()` will block until there is enough space in the buffer. To avoid blocking calls to `Serial.write()`, you can first check the amount of free space in the transmit buffer using link:../availableforwrite[availableForWrite()].
+Serial transmission is asynchronous. If there is enough empty space in the transmit buffer, `Serial.write()` will return before any characters are transmitted over serial. If the transmit buffer is full then `Serial.write()` will block until there is enough space in the buffer. To avoid blocking calls to `Serial.write()`, you can first check the amount of free space in the transmit buffer using link:../availableforwrite[availableForWrite()].
 
 --
 // HOW TO USE SECTION ENDS

--- a/Language/Functions/Communication/Wire.adoc
+++ b/Language/Functions/Communication/Wire.adoc
@@ -16,7 +16,7 @@ subCategories: [ "Communication" ]
 === Description
 
 
-This library allows you to communicate with I2C/TWI devices. On the Arduino boards with the R3 layout (1.0 pinout), the SDA (data line) and SCL (clock line) are on the pin headers close to the AREF pin. The Arduino Due has two I2C/TWI interfaces SDA1 and SCL1 are near to the AREF pin and the additional one is on pins 20 and 21.
+This library allows you to communicate with I2C/TWI devices. On the Arduino boards with the R3 layout, the SDA (data line) and SCL (clock line) are on the pin headers close to the AREF pin. The Arduino Due has two I2C/TWI interfaces SDA1 and SCL1 are near to the AREF pin and the additional one is on pins 20 and 21.
 
 As a reference the table below shows where TWI pins are located on various Arduino boards.
 
@@ -36,7 +36,7 @@ As a reference the table below shows where TWI pins are located on various Ardui
 |=== 
 
 
-As of Arduino 1.0, the library inherits from the Stream functions, making it consistent with other read/write libraries. Because of this, `send()` and `receive()` have been replaced with `read()` and `write()`.
+This library inherits from the Stream functions, making it consistent with other read/write libraries. Because of this, `send()` and `receive()` have been replaced with `read()` and `write()`.
 
 Recent versions of the Wire library can use timeouts to prevent a lockup in the face of certain problems on the bus, but this is not enabled by default (yet) in current versions. It is recommended to always enable these timeouts when using the Wire library. See the Wire.setWireTimeout function for more details.
 

--- a/Language/Functions/Communication/Wire/endTransmission.adoc
+++ b/Language/Functions/Communication/Wire/endTransmission.adoc
@@ -10,7 +10,7 @@ title: endTransmission()
 
 [float]
 === Description
-This function ends a transmission to a peripheral device that was begun by `beginTransmission()` and transmits the bytes that were queued by `write()`. As of Arduino 1.0.1, `endTransmission()` accepts a boolean argument changing its behavior for compatibility with certain I2C devices. If true, `endTransmission()` sends a stop message after transmission, releasing the I2C bus. If false, `endTransmission()` sends a restart message after transmission. The bus will not be released, which prevents another controller device from transmitting between messages. This allows one controller device to send multiple transmissions while in control. The default value is true.
+This function ends a transmission to a peripheral device that was begun by `beginTransmission()` and transmits the bytes that were queued by `write()`. The `endTransmission()` method accepts a boolean argument changing its behavior for compatibility with certain I2C devices. If true, `endTransmission()` sends a stop message after transmission, releasing the I2C bus. If false, `endTransmission()` sends a restart message after transmission. The bus will not be released, which prevents another controller device from transmitting between messages. This allows one controller device to send multiple transmissions while in control. The default value is true.
 
 [float]
 === Syntax

--- a/Language/Functions/Communication/Wire/requestFrom.adoc
+++ b/Language/Functions/Communication/Wire/requestFrom.adoc
@@ -11,7 +11,7 @@ title: requestFrom()
 
 [float]
 === Description
-This function is used by the controller device to request bytes from a peripheral device. The bytes may then be retrieved with the `available()` and `read()` functions. As of Arduino 1.0.1, `requestFrom()` accepts a boolean argument changing its behavior for compatibility with certain I2C devices. If true, `requestFrom()` sends a stop message after the request, releasing the I2C bus. If false, `requestFrom()` sends a restart message after the request. The bus will not be released, which prevents another master device from requesting between messages. This allows one master device to send multiple requests while in control. The default value is true.
+This function is used by the controller device to request bytes from a peripheral device. The bytes may then be retrieved with the `available()` and `read()` functions. The `requestFrom()` method accepts a boolean argument changing its behavior for compatibility with certain I2C devices. If true, `requestFrom()` sends a stop message after the request, releasing the I2C bus. If false, `requestFrom()` sends a restart message after the request. The bus will not be released, which prevents another master device from requesting between messages. This allows one master device to send multiple requests while in control. The default value is true.
 
 [float]
 === Syntax

--- a/Language/Functions/Digital IO/pinMode.adoc
+++ b/Language/Functions/Digital IO/pinMode.adoc
@@ -19,7 +19,7 @@ subCategories: [ "Digital I/O" ]
 === Description
 Configures the specified pin to behave either as an input or an output. See the http://arduino.cc/en/Tutorial/DigitalPins[Digital Pins] page for details on the functionality of the pins.
 [%hardbreaks]
-As of Arduino 1.0.1, it is possible to enable the internal pullup resistors with the mode `INPUT_PULLUP`. Additionally, the `INPUT` mode explicitly disables the internal pullups.
+It is possible to enable the internal pullup resistors with the mode `INPUT_PULLUP`. Additionally, the `INPUT` mode explicitly disables the internal pullups.
 [%hardbreaks]
 
 

--- a/Language/Functions/Time/delayMicroseconds.adoc
+++ b/Language/Functions/Time/delayMicroseconds.adoc
@@ -73,8 +73,6 @@ void loop() {
 === Notes and Warnings
 This function works very accurately in the range 3 microseconds and up to 16383. We cannot assure that delayMicroseconds will perform precisely for smaller delay-times. Larger delay times may actually delay for an extremely brief time. 
 
-As of Arduino 0018, delayMicroseconds() no longer disables interrupts.
-
 --
 // HOW TO USE SECTION ENDS
 

--- a/Language/Variables/Data Types/String/Functions/toLowerCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/toLowerCase.adoc
@@ -17,7 +17,7 @@ subCategories: [ "StringObject Function" ]
 
 [float]
 === Description
-Get a lower-case version of a String. As of 1.0, toLowerCase() modifies the String in place rather than returning a new one.
+Get a lower-case version of a String. The `toLowerCase()` function modifies the String in place rather than returning a new one.
 
 [%hardbreaks]
 

--- a/Language/Variables/Data Types/String/Functions/toUpperCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/toUpperCase.adoc
@@ -17,7 +17,7 @@ subCategories: [ "StringObject Function" ]
 
 [float]
 === Description
-Get an upper-case version of a String. As of 1.0, toUpperCase() modifies the String in place rather than returning a new one.
+Get an upper-case version of a String. The `toUpperCase()` modifies the String in place rather than returning a new one.
 [%hardbreaks]
 
 

--- a/Language/Variables/Data Types/String/Functions/trim.adoc
+++ b/Language/Variables/Data Types/String/Functions/trim.adoc
@@ -17,7 +17,7 @@ subCategories: [ "StringObject Function" ]
 
 [float]
 === Description
-Get a version of the String with any leading and trailing whitespace removed. As of 1.0, trim() modifies the String in place rather than returning a new one.
+Get a version of the String with any leading and trailing whitespace removed. The `trim()` function modifies the String in place rather than returning a new one.
 
 [%hardbreaks]
 

--- a/Language/Variables/Data Types/string.adoc
+++ b/Language/Variables/Data Types/string.adoc
@@ -12,7 +12,7 @@ subCategories: [ "Data Types" ]
 
 [float]
 === Description
-Text strings can be represented in two ways. you can use the String data type, which is part of the core as of version 0019, or you can make a string out of an array of type char and null-terminate it. This page described the latter method. For more details on the String object, which gives you more functionality at the cost of more memory, see the link:../stringobject[String object] page.
+Text strings can be represented in two ways. you can use the String data type, or you can make a string out of an array of type char and null-terminate it. This page described the latter method. For more details on the String object, which gives you more functionality at the cost of more memory, see the link:../stringobject[String object] page.
 [%hardbreaks]
 
 [float]


### PR DESCRIPTION
Mentions referring to versions below 1.0 was removed. These are likely 15+ years old, as we are now in version 2.3.x of the IDE