### PR TITLE
Constant Link fixes

### DIFF
--- a/Language/Functions/Advanced IO/pulseIn.adoc
+++ b/Language/Functions/Advanced IO/pulseIn.adoc
@@ -34,7 +34,7 @@ NOTE:  if the optional timeout is used code will execute faster.
 [float]
 === Parameters
 `pin`: the number of the Arduino pin on which you want to read the pulse. Allowed data types: `int`. +
-`value`: type of pulse to read: either link:../../../variables/constants/constants[HIGH] or link:../../../variables/constants/constants[LOW]. Allowed data types: `int`. +
+`value`: type of pulse to read: either link:../../../variables/constants/highlow/[HIGH] or link:../../../variables/constants/highlow/[LOW]. Allowed data types: `int`. +
 `timeout` (optional): the number of microseconds to wait for the pulse to start; default is one second. Allowed data types: `unsigned long`.
 
 

--- a/Language/Functions/Advanced IO/pulseInLong.adoc
+++ b/Language/Functions/Advanced IO/pulseInLong.adoc
@@ -34,7 +34,7 @@ The timing of this function has been determined empirically and will probably sh
 [float]
 === Parameters
 `pin`: the number of the Arduino pin on which you want to read the pulse. Allowed data types: `int`. +
-`value`: type of pulse to read: either link:../../../variables/constants/constants[HIGH] or link:../../../variables/constants/constants[LOW]. Allowed data types: `int`. +
+`value`: type of pulse to read: either link:../../../variables/constants/highlow/[HIGH] or link:../../../variables/constants/highlow/[LOW]. Allowed data types: `int`. +
 `timeout` (optional): the number of microseconds to wait for the pulse to start; default is one second. Allowed data types: `unsigned long`.
 
 

--- a/Language/Structure/Control Structure/doWhile.adoc
+++ b/Language/Structure/Control Structure/doWhile.adoc
@@ -32,7 +32,7 @@ do {
 
 [float]
 === Parameters
-`condition`: a boolean expression that evaluates to `link:../../../variables/constants/constants[true]` or `link:../../../variables/constants/constants[false]`.
+`condition`: a boolean expression that evaluates to `link:../../../variables/constants/truefalse[true]` or `link:../../../variables/constants/truefalse[false]`.
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Control Structure/for.adoc
+++ b/Language/Structure/Control Structure/for.adoc
@@ -34,8 +34,8 @@ for (initialization; condition; increment) {
 [float]
 === Parameters
 `initialization`: happens first and exactly once. +
-`condition`: each time through the loop, `condition` is tested; if it's `link:../../../variables/constants/constants[true]`, the statement block, and the *increment* is executed, then the *condition* is tested again. When the *condition* becomes `link:../../../variables/constants/constants[false]`, the loop ends. +
-`increment`: executed each time through the loop when `condition` is link:../../../variables/constants/constants[`true`].
+`condition`: each time through the loop, `condition` is tested; if it's `link:../../../variables/constants/truefalse[true]`, the statement block, and the *increment* is executed, then the *condition* is tested again. When the *condition* becomes `link:../../../variables/constants/truefalse[false]`, the loop ends. +
+`increment`: executed each time through the loop when `condition` is link:../../../variables/constants/truefalse[`true`].
 
 --
 // OVERVIEW SECTION ENDS

--- a/Language/Structure/Further Syntax/define.adoc
+++ b/Language/Structure/Further Syntax/define.adoc
@@ -89,7 +89,6 @@ Similarly, including an equal sign after the #define statement will also generat
 
 [role="language"]
 * #LANGUAGE# link:../../../variables/variable-scope-qualifiers/const[const]
-* #LANGUAGE# link:../../../variables/constants/constants[Constants]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/bool.adoc
+++ b/Language/Variables/Data Types/bool.adoc
@@ -12,7 +12,7 @@ subCategories: [ "Data Types" ]
 
 [float]
 === Description
-A `bool` holds one of two values, `link:../../constants/constants[true]` or `link:../../constants/constants[false]`. (Each `bool` variable occupies one byte of memory.)
+A `bool` holds one of two values, `link:../../constants/truefalse[true]` or `link:../../constants/truefalse[false]`. (Each `bool` variable occupies one byte of memory.)
 
 
 [%hardbreaks]
@@ -77,8 +77,6 @@ void loop() {
 [float]
 === See also
 
-[role="language"]
-* #LANGUAGE# link:../../../variables/constants/constants[constants]
 
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
Links pointing to `/constants/constants` have been replaced with the new url (e.g. `highlow`, `truefalse` etc.)