### PR TITLE
serialEvent() description update.

### DIFF
--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -15,6 +15,8 @@ title: serialEvent()
 [float]
 === Description
 Called at the end of link:../../../../structure/sketch/loop[`loop()`] when data is available. Use `Serial.read()` to capture this data.
+
+*Please note:* most modern boards do not support this method. See "Notes and Warnings" further below this article.
 [%hardbreaks]
 
 
@@ -63,11 +65,9 @@ Nothing
 
 [float]
 === Notes and Warnings
-`serialEvent()` doesn't work on the Leonardo, Micro, or Yún.
+Please note that `serialEvent()` *does not work* on any modern Arduino boards. The only recognized boards to have support as of 2023/12/06 is the *UNO R3* and *Mega 2560 R3*, which are based on the ATmega328P chip. 
 
-`serialEvent()` and `serialEvent1()` don't work on the Arduino SAMD Boards
-
-`serialEvent()`, `serialEvent1()`, `serialEvent2()`, and `serialEvent3()`  don't work on the Arduino Due.
+Instead, you can use the link:../available[`available()`] method. Examples in this page demonstrates how to read serial data only when it is available, which is exactly what `Serial.event()` does.
 [%hardbreaks]
 
 --

--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -29,7 +29,9 @@ void serialEvent() {
   //statements
 }
 ----
-For boards with additional serial ports (see the list of available serial ports for each board on the link:../../serial[Serial main page]):
+
+The Mega 2560 R3 has additional serial ports which can be accessed by adding the corresponding number at the end of the function.
+
 [source,arduino]
 ----
 void serialEvent1() {
@@ -65,7 +67,7 @@ Nothing
 
 [float]
 === Notes and Warnings
-Please note that `serialEvent()` *does not work* on any modern Arduino boards. The only recognized boards to have support as of 2023/12/06 is the *UNO R3* and *Mega 2560 R3*, which are based on the ATmega328P chip. 
+Please note that `serialEvent()` *does not work* on any modern Arduino boards. The only recognized boards to have support as of 2023/12/06 is the *UNO R3* and *Mega 2560 R3*, which are based on the ATmega328P and ATmega2560 chips. 
 
 Instead, you can use the link:../available[`available()`] method. Examples in this page demonstrates how to read serial data only when it is available, which is exactly what `Serial.event()` does.
 [%hardbreaks]


### PR DESCRIPTION
`serialEvent()` is not supported on any modern boards (from Leonardo/Micro and onwards). This PR adds a note that the only recognized boards to be supported is the UNO R3 and Mega 2560 R3, and that modern boards should instead use the `if(Serial.available() > 0)` approach.