### PR TITLE
Fix incorrect link

### DIFF
--- a/Language/Functions/USB/Keyboard.adoc
+++ b/Language/Functions/USB/Keyboard.adoc
@@ -38,7 +38,7 @@ HID is supported on the following boards:
 | link:https://docs.arduino.cc/hardware/uno-r4-wifi[UNO R4 WiFi]       | All digital & analog pins
 | link:https://docs.arduino.cc/hardware/giga-r1[Giga R1]               | All digital & analog pins
 | link:https://docs.arduino.cc/hardware/nano-esp32[Nano ESP32]         | All digital & analog pins
-| link:https://docs.arduino.cc/hardware/mkr-1000-wifi[Nano ESP32]      | All digital & analog pins
+| link:https://docs.arduino.cc/hardware/mkr-1000-wifi[MKR 1000 WiFi]   | All digital & analog pins
 | link:https://docs.arduino.cc/#mkr-family[MKR Family]                 | All digital & analog pins
 |=================================================================================================
 

--- a/Language/Functions/USB/Mouse.adoc
+++ b/Language/Functions/USB/Mouse.adoc
@@ -37,7 +37,7 @@ HID is supported on the following boards:
 | link:https://docs.arduino.cc/hardware/uno-r4-wifi[UNO R4 WiFi]       | All digital & analog pins
 | link:https://docs.arduino.cc/hardware/giga-r1[Giga R1]               | All digital & analog pins
 | link:https://docs.arduino.cc/hardware/nano-esp32[Nano ESP32]         | All digital & analog pins
-| link:https://docs.arduino.cc/hardware/mkr-1000-wifi[Nano ESP32]      | All digital & analog pins
+| link:https://docs.arduino.cc/hardware/mkr-1000-wifi[MKR 1000 WiFi]   | All digital & analog pins
 | link:https://docs.arduino.cc/#mkr-family[MKR Family]                 | All digital & analog pins
 |=================================================================================================
 


### PR DESCRIPTION
This PR fixes an incorrect link in the compatible board table for the mouse and keyboard reference.