### PR TITLE
Add word 'specify' to entries in switch...case parameter descriptions

### DIFF
--- a/Language/Structure/Control Structure/switchCase.adoc
+++ b/Language/Structure/Control Structure/switchCase.adoc
@@ -72,10 +72,10 @@ Nothing
 ----
 switch (var) {
   case 1:
-    //do something when var equals 1
+    // do something when var equals 1
     break;
   case 2:
-    //do something when var equals 2
+    // do something when var equals 2
     break;
   default:
     // if nothing else matches, do the default

--- a/Language/Structure/Control Structure/switchCase.adoc
+++ b/Language/Structure/Control Structure/switchCase.adoc
@@ -47,7 +47,7 @@ switch (var) {
 `var`: an *integer* variable whose value to compare with various cases. Any integer data type is allowed*, such as `byte`, `char`, `int`, `long`.
 `label1`, `label2`: constants. Any integer data type here is also allowed.
 
-*You can also use the `bool` data type when you just two switch cases.
+*You can also use the `bool` data type when you specify just two switch cases.
 
 Note that you can also use negative values as input.
 


### PR DESCRIPTION
The sentences in the parameter descriptions for the switch...case control structure documentation don't read well in my opinion, I think they need to use the word 'specify' e.g. "You can also use the `bool` data type when you **specify** just two switch cases."

I also think the code example should consistently use a space between the single line comment slashes and the comment text.