### PR TITLE
Updating interruptions information

### DIFF
--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -63,10 +63,12 @@ For more information on interrupts, see http://gammon.com.au/interrupts[Nick Gam
 
 [float]
 === Syntax
+
+The attachInterrupt() first parameter is a *pinNumber* starting from *ArduinoCore-API 1.0*. For legacy reasons (for example, if targeting an AVR board) you can still pass the argument via the old digitalPinToInterrupt() macro. This macro expands into the pinNumber in modern architectures, thus cannot be used to evaluate if a pin is interrupt capable.
+
 `attachInterrupt(digitalPinToInterrupt(pin), ISR, mode)` (recommended) +
 `attachInterrupt(interrupt, ISR, mode)` (not recommended) +
 `attachInterrupt(pin, ISR, mode)` (Not recommended. Additionally, this syntax only works on Arduino SAMD Boards, Uno WiFi Rev2, Due, and 101.)
-
 
 [float]
 === Parameters
@@ -150,6 +152,10 @@ For Uno WiFi Rev2, Due, Zero, MKR Family and 101 boards the *interrupt number = 
 
 [float]
 === See also
+
+[role="language"]
+* #LANGUAGE# link:../../external-interrupts/detachinterrupt[detachInterrupts()]
+* #LANGUAGE# link:../../external-interrupts/digitalpintointerrupt[digitalPinToInterrupt()]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -66,13 +66,11 @@ For more information on interrupts, see http://gammon.com.au/interrupts[Nick Gam
 
 The attachInterrupt() first parameter is a *pinNumber* starting from *ArduinoCore-API 1.0*. For legacy reasons (for example, if targeting an AVR board) you can still pass the argument via the old digitalPinToInterrupt() macro. This macro expands into the pinNumber in modern architectures, thus cannot be used to evaluate if a pin is interrupt capable.
 
-`attachInterrupt(digitalPinToInterrupt(pin), ISR, mode)` (recommended) +
-`attachInterrupt(interrupt, ISR, mode)` (not recommended) +
-`attachInterrupt(pin, ISR, mode)` (Not recommended. Additionally, this syntax only works on Arduino SAMD Boards, Uno WiFi Rev2, Due, and 101.)
+`attachInterrupt(pin, ISR, mode)`
+`attachInterrupt(digitalPinToInterrupt(pin), ISR, mode)` (AVR and older boards) +
 
 [float]
 === Parameters
-`interrupt`: the number of the interrupt. Allowed data types: `int`. +
 `pin`: the Arduino pin number. +
 `ISR`: the ISR to call when the interrupt occurs; this function must take no parameters and return nothing. This function is sometimes referred to as an interrupt service routine. +
 `mode`: defines when the interrupt should be triggered. Four constants are predefined as valid values: +

--- a/Language/Functions/External Interrupts/digitalPinToInterrupt.adoc
+++ b/Language/Functions/External Interrupts/digitalPinToInterrupt.adoc
@@ -17,7 +17,10 @@ subCategories: [ "External Interrupts" ]
 
 [float]
 === Description
-The `digitalPinToInterrupt()` function takes a pin as an argument, and returns the same pin *if* it can be used as an interrupt. For example, `digitalPinToInterrupt(4)` on an Arduino UNO will not work, as interrupts are only supported on pins 2,3.
+
+*AVR only*: The `digitalPinToInterrupt()` returns the interrupt number for a specific pin. If the provided pin is not interrupt capable, returns NOT_AN_INTERRUPT (-1). For example: `digitalPinToInterrupt(4)` on an Arduino UNO will not work, as interrupts are only supported on pins 2,3.
+
+*All other platforms*: Returns the parameter, without checking for interrupt capability. attachInterrupt() implementation should perform the check instead. For example, `digitalPinToInterrupt(4)` on an Arduino UNO R4 WiFi will return *4* without checking if it is an interrupt pin.
 
 See link:../../external-interrupts/attachinterrupt[attachInterrupt()] for a full list of supported interrupt pins on all boards.
 
@@ -37,7 +40,7 @@ See link:../../external-interrupts/attachinterrupt[attachInterrupt()] for a full
 [float]
 === Returns
 - The pin to interrupt (e.g. `2`)+
-- If pin is not available for interrupt, returns `-1`.
+- *AVR only*: If pin is not available for interrupt, returns `-1`.
 
 --
 // OVERVIEW SECTION ENDS


### PR DESCRIPTION
diitalPinToInterrupt is not working as described in the [reference](https://www.arduino.cc/reference/en/language/functions/external-interrupts/digitalpintointerrupt/) since it only works as described for AVR and old boards, but for the new architectures, that function always returns the same parameter as received.