### PR TITLE
Update analogWrite.adoc

### DIFF
--- a/Language/Functions/Analog IO/analogWrite.adoc
+++ b/Language/Functions/Analog IO/analogWrite.adoc
@@ -83,7 +83,7 @@ Sets the output to the LED proportional to the value read from the potentiometer
 [source,arduino]
 ----
 int ledPin = 9;      // LED connected to digital pin 9
-int analogPin = 3;   // potentiometer connected to analog pin 3
+int analogPin = A3;  // potentiometer connected to analog pin 3
 int val = 0;         // variable to store the read value
 
 void setup() {


### PR DESCRIPTION
resolves #979 
Corrected the typo in the document, relating to the pot being connected to pin 3, vs pin A3.