### PR TITLE
Update clearWireTimeoutFlag.adoc

### DIFF
--- a/Language/Functions/Communication/Wire/clearWireTimeoutFlag.adoc
+++ b/Language/Functions/Communication/Wire/clearWireTimeoutFlag.adoc
@@ -18,7 +18,7 @@ Timeouts might not be enabled by default. See the documentation for `Wire.setWir
 [float]
 === Syntax
 
-`Wire.clearTimeout()`
+`Wire.clearTimeoutFlag()`
 
 [float]
 === Parameters


### PR DESCRIPTION
The syntax of the discription of the function used the old name of the function, i.e. clearTimeout() instead of clearTimeoutFlag()