### PR TITLE
Fix the data types for the function sq()

### DIFF
--- a/Language/Functions/Math/sq.adoc
+++ b/Language/Functions/Math/sq.adoc
@@ -28,12 +28,12 @@ Calculates the square of a number: the number multiplied by itself.
 
 [float]
 === Parameters
-`x`: the number. Allowed data types: any data type.
+`x`: the number. Allowed data types: any numeric type.
 
 
 [float]
 === Returns
-The square of the number. Data type: `double`.
+The square of the number. Data type: `int` if the argument type is smaller than an `int` (e.g. `char`), otherwise the returned value has the same type as the argument.
 
 --
 // OVERVIEW SECTION ENDS


### PR DESCRIPTION
The current description states that the argument of `sq()` can have “any data type”, whereas only numeric types can be used.

The current description states that the returned value is a “`double`”, but this is only true if the argument is itself a `double`.

This pull request attempts to fix the types. It is, however, impossible to give a completely accurate description of the returned type without fully stating all the C++ rules of [integral promotion][cppref], and this would be too much for the intended audience.

As a compromise, the proposed description is:

> Data type: `int` if the argument type is smaller than an `int` (e.g. `char`), otherwise the returned value has the same type as the argument.

This captures the gist of integral promotion, and should be accurate on ILP32 (ARM). On IP16 (AVR), however, this simplified description implies that `sq(short_var)` is a `short`, whereas it is actually an `int`. I deem the inaccuracy acceptable given that, on IP16, `short` and `int` are basically the same thing (they have the same underlying representation).

[cppref]: https://en.cppreference.com/w/cpp/language/implicit_conversion#Integral_promotion