### PR TITLE
Fix the list of hexadecimal characters in isHexadecimalDigit.adoc

### DIFF
--- a/Language/Functions/Characters/isHexadecimalDigit.adoc
+++ b/Language/Functions/Characters/isHexadecimalDigit.adoc
@@ -17,7 +17,7 @@ subCategories: [ "Characters" ]
 
 [float]
 === Description
-Analyse if a char is an hexadecimal digit (A-F, 0-9). Returns true if thisChar contains an hexadecimal digit.
+Analyse if a char is an hexadecimal digit (0-9, A-F, a-f). Returns true if thisChar contains an hexadecimal digit.
 [%hardbreaks]
 
 


### PR DESCRIPTION
The [documentation of `isHexadecimalDigit()`][doc] states:

> Analyse if a char is an hexadecimal digit (A-F, 0-9).

Contrary to what is implied here, the _lowercase_ letters “a” through “f” are also identified as hexadecimal digits by this function.

This pull request completes the list of characters, and sorts them by ASCII order: 0–9, A–F, a–f.

[doc]: https://docs.arduino.cc/language-reference/en/functions/characters/isHexadecimalDigit/
